### PR TITLE
Fix broken JSDoc reference Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ JSDoc grammar for [tree-sitter][].
 
 References
 
-* [UseJSDoc.org](http://usejsdoc.org/)
+* [UseJSDoc](https://jsdoc.app/)


### PR DESCRIPTION
http://usejsdoc.org/ no longer exists, the correct url for the spec is http://usejsdoc.org/