### PR TITLE
Add Swift Bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 package-lock.json
 target
 Cargo.lock
+./build

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ build
 package-lock.json
 target
 Cargo.lock
-./build
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterJSDoc",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterJSDoc", targets: ["TreeSitterJSDoc"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterJSDoc",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "corpus",
+                    "grammar.js",
+                    "LICENSE",
+                    "package.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/jsdoc.h
+++ b/bindings/swift/jsdoc.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_JSDOC_H_
+#define TREE_SITTER_JSDOC_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_jdsoc();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_JSDOC_H_

--- a/bindings/swift/jsdoc.h
+++ b/bindings/swift/jsdoc.h
@@ -7,7 +7,7 @@ typedef struct TSLanguage TSLanguage;
 extern "C" {
 #endif
 
-extern TSLanguage *tree_sitter_jdsoc();
+extern TSLanguage *tree_sitter_jsdoc();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The Swift Package manager can build C and C++ sources and use headers to expose functions to Swift. 

These additions and modifications allow the SPM to use the JSDoc Tree Sitter and for use in Swift apps.