### PR TITLE
Permit braces in more contexts

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,22 @@
+name: Fuzz Parser
+
+on:
+  push:
+    paths:
+      - src/scanner.c
+  pull_request:
+    paths:
+      - src/scanner.c
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Parser fuzzing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: vigoux/tree-sitter-fuzz-action@v1
+        with:
+          language: jsdoc
+          external-scanner: src/scanner.c
+          time: 60

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
                 ],
                 sources: [
                     "src/parser.c",
+                    "src/scanner.c",
                 ],
                 resources: [
                     .copy("queries")

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,8 @@
       ],
       "sources": [
         "src/parser.c",
-        "bindings/node/binding.cc"
+        "bindings/node/binding.cc",
+        "src/scanner.c",
       ],
       "cflags_c": [
         "-std=c99",

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -10,6 +10,10 @@ fn main() {
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 }

--- a/grammar.js
+++ b/grammar.js
@@ -71,7 +71,7 @@ module.exports = grammar({
     ),
 
     _inline_tag_false_positive: _ => prec.left(1, seq(
-      '{',
+      /{/,
       /[^@}]+/,
       optional(/}/),
     )),

--- a/grammar.js
+++ b/grammar.js
@@ -15,6 +15,10 @@
 module.exports = grammar({
   name: 'jsdoc',
 
+  externals: $ => [
+    $.type,
+  ],
+
   extras: _ => [
     token(choice(
       // Skip over stars at the beginnings of lines
@@ -33,7 +37,7 @@ module.exports = grammar({
 
     description: $ => seq(
       $._text,
-      repeat(choice($._text, $.inline_tag)),
+      repeat(choice($._text, $.inline_tag, $._inline_tag_false_positive)),
     ),
 
     tag: $ => choice(
@@ -66,6 +70,12 @@ module.exports = grammar({
       '}',
     ),
 
+    _inline_tag_false_positive: _ => prec.left(1, seq(
+      '{',
+      /[^@}]+/,
+      optional('}'),
+    )),
+
     tag_name_with_argument: _ => token(choice(
       '@access',
       '@alias',
@@ -95,6 +105,7 @@ module.exports = grammar({
       '@returns',
       '@throw',
       '@throws',
+      '@type',
     )),
 
     tag_name: _ => /@[a-zA-Z_]+/,
@@ -135,8 +146,6 @@ module.exports = grammar({
     optional_identifier: $ => seq('[', $.identifier, ']'),
 
     identifier: _ => /[a-zA-Z_$][a-zA-Z_$0-9]*/,
-
-    type: _ => /[^}\n]+/,
 
     _text: _ => token(prec(-1, /[^*{}@\s][^*{}\n]*([^*/{}\n][^*{}\n]*\*+)*/)),
 

--- a/grammar.js
+++ b/grammar.js
@@ -73,7 +73,7 @@ module.exports = grammar({
     _inline_tag_false_positive: _ => prec.left(1, seq(
       '{',
       /[^@}]+/,
-      optional('}'),
+      optional(/}/),
     )),
 
     tag_name_with_argument: _ => token(choice(

--- a/grammar.js
+++ b/grammar.js
@@ -70,11 +70,7 @@ module.exports = grammar({
       '}',
     ),
 
-    _inline_tag_false_positive: _ => prec.left(1, seq(
-      /{/,
-      /[^@}]+/,
-      optional(/}/),
-    )),
+    _inline_tag_false_positive: _ => token(prec.left(1, /\{[^@}]+\}?/)),
 
     tag_name_with_argument: _ => token(choice(
       '@access',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -241,7 +241,7 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "STRING",
+                "type": "PATTERN",
                 "value": "}"
               },
               {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -52,6 +52,10 @@
               {
                 "type": "SYMBOL",
                 "name": "inline_tag"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_inline_tag_false_positive"
               }
             ]
           }
@@ -219,6 +223,35 @@
         }
       ]
     },
+    "_inline_tag_false_positive": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "{"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^@}]+"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "}"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
     "tag_name_with_argument": {
       "type": "TOKEN",
       "content": {
@@ -331,6 +364,10 @@
           {
             "type": "STRING",
             "value": "@throws"
+          },
+          {
+            "type": "STRING",
+            "value": "@type"
           }
         ]
       }
@@ -469,10 +506,6 @@
       "type": "PATTERN",
       "value": "[a-zA-Z_$][a-zA-Z_$0-9]*"
     },
-    "type": {
-      "type": "PATTERN",
-      "value": "[^}\\n]+"
-    },
     "_text": {
       "type": "TOKEN",
       "content": {
@@ -553,7 +586,12 @@
   ],
   "conflicts": [],
   "precedences": [],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "type"
+    }
+  ],
   "inline": [],
   "supertypes": []
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -224,32 +224,14 @@
       ]
     },
     "_inline_tag_false_positive": {
-      "type": "PREC_LEFT",
-      "value": 1,
+      "type": "TOKEN",
       "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "{"
-          },
-          {
-            "type": "PATTERN",
-            "value": "[^@}]+"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "}"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        ]
+        "type": "PREC_LEFT",
+        "value": 1,
+        "content": {
+          "type": "PATTERN",
+          "value": "\\{[^@}]+\\}?"
+        }
       }
     },
     "tag_name_with_argument": {

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,11 +6,11 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 54
+#define STATE_COUNT 55
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 31
+#define SYMBOL_COUNT 32
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 19
+#define TOKEN_COUNT 20
 #define EXTERNAL_TOKEN_COUNT 1
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
@@ -20,33 +20,34 @@ enum ts_symbol_identifiers {
   anon_sym_LBRACE = 1,
   anon_sym_RBRACE = 2,
   aux_sym__inline_tag_false_positive_token1 = 3,
-  sym_tag_name_with_argument = 4,
-  sym_tag_name_with_type = 5,
-  sym_tag_name = 6,
-  anon_sym_COLON = 7,
-  anon_sym_SLASH = 8,
-  anon_sym_DOT = 9,
-  anon_sym_POUND = 10,
-  anon_sym_TILDE = 11,
-  anon_sym_LBRACK = 12,
-  anon_sym_RBRACK = 13,
-  sym_identifier = 14,
-  sym__text = 15,
-  sym__begin = 16,
-  sym__end = 17,
-  sym_type = 18,
-  sym_document = 19,
-  sym_description = 20,
-  sym_tag = 21,
-  sym_inline_tag = 22,
-  sym__inline_tag_false_positive = 23,
-  sym__expression = 24,
-  sym_qualified_expression = 25,
-  sym_path_expression = 26,
-  sym_member_expression = 27,
-  sym_optional_identifier = 28,
-  aux_sym_document_repeat1 = 29,
-  aux_sym_description_repeat1 = 30,
+  aux_sym__inline_tag_false_positive_token2 = 4,
+  sym_tag_name_with_argument = 5,
+  sym_tag_name_with_type = 6,
+  sym_tag_name = 7,
+  anon_sym_COLON = 8,
+  anon_sym_SLASH = 9,
+  anon_sym_DOT = 10,
+  anon_sym_POUND = 11,
+  anon_sym_TILDE = 12,
+  anon_sym_LBRACK = 13,
+  anon_sym_RBRACK = 14,
+  sym_identifier = 15,
+  sym__text = 16,
+  sym__begin = 17,
+  sym__end = 18,
+  sym_type = 19,
+  sym_document = 20,
+  sym_description = 21,
+  sym_tag = 22,
+  sym_inline_tag = 23,
+  sym__inline_tag_false_positive = 24,
+  sym__expression = 25,
+  sym_qualified_expression = 26,
+  sym_path_expression = 27,
+  sym_member_expression = 28,
+  sym_optional_identifier = 29,
+  aux_sym_document_repeat1 = 30,
+  aux_sym_description_repeat1 = 31,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -54,6 +55,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LBRACE] = "{",
   [anon_sym_RBRACE] = "}",
   [aux_sym__inline_tag_false_positive_token1] = "_inline_tag_false_positive_token1",
+  [aux_sym__inline_tag_false_positive_token2] = "_inline_tag_false_positive_token2",
   [sym_tag_name_with_argument] = "tag_name",
   [sym_tag_name_with_type] = "tag_name",
   [sym_tag_name] = "tag_name",
@@ -88,6 +90,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LBRACE] = anon_sym_LBRACE,
   [anon_sym_RBRACE] = anon_sym_RBRACE,
   [aux_sym__inline_tag_false_positive_token1] = aux_sym__inline_tag_false_positive_token1,
+  [aux_sym__inline_tag_false_positive_token2] = aux_sym__inline_tag_false_positive_token2,
   [sym_tag_name_with_argument] = sym_tag_name,
   [sym_tag_name_with_type] = sym_tag_name,
   [sym_tag_name] = sym_tag_name,
@@ -131,6 +134,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [aux_sym__inline_tag_false_positive_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym__inline_tag_false_positive_token2] = {
     .visible = false,
     .named = false,
   },
@@ -286,15 +293,15 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [30] = 30,
   [31] = 31,
   [32] = 32,
-  [33] = 33,
-  [34] = 23,
-  [35] = 18,
-  [36] = 36,
+  [33] = 18,
+  [34] = 34,
+  [35] = 23,
+  [36] = 19,
   [37] = 37,
   [38] = 38,
-  [39] = 36,
+  [39] = 39,
   [40] = 37,
-  [41] = 41,
+  [41] = 38,
   [42] = 42,
   [43] = 43,
   [44] = 44,
@@ -305,8 +312,9 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [49] = 49,
   [50] = 50,
   [51] = 51,
-  [52] = 41,
-  [53] = 53,
+  [52] = 52,
+  [53] = 45,
+  [54] = 54,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -316,47 +324,47 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 0:
       if (eof) ADVANCE(20);
       if (lookahead == '\n') SKIP(18)
-      if (lookahead == '#') ADVANCE(130);
-      if (lookahead == '.') ADVANCE(129);
-      if (lookahead == '/') ADVANCE(128);
-      if (lookahead == ':') ADVANCE(126);
+      if (lookahead == '#') ADVANCE(131);
+      if (lookahead == '.') ADVANCE(130);
+      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == ':') ADVANCE(127);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '[') ADVANCE(132);
-      if (lookahead == ']') ADVANCE(133);
+      if (lookahead == '[') ADVANCE(133);
+      if (lookahead == ']') ADVANCE(134);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
-      if (lookahead == '~') ADVANCE(131);
+      if (lookahead == '~') ADVANCE(132);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(19)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(137);
+          lookahead != '*') ADVANCE(138);
       END_STATE();
     case 1:
       if (lookahead == '\n') SKIP(1)
       if (lookahead == '*') SKIP(1)
-      if (lookahead == '/') ADVANCE(138);
-      if (lookahead == ']') ADVANCE(133);
+      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == ']') ADVANCE(134);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(1)
       if ((11 <= lookahead && lookahead <= '\r')) SKIP(2)
       END_STATE();
     case 2:
       if (lookahead == '\n') SKIP(1)
-      if (lookahead == '/') ADVANCE(138);
-      if (lookahead == ']') ADVANCE(133);
+      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == ']') ADVANCE(134);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
       if (lookahead == '\n') SKIP(3)
       if (lookahead == '*') SKIP(3)
-      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == '/') ADVANCE(140);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '[') ADVANCE(132);
+      if (lookahead == '[') ADVANCE(133);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(3)
@@ -364,123 +372,123 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(137);
+          lookahead != '}') ADVANCE(138);
       END_STATE();
     case 4:
       if (lookahead == '\n') SKIP(3)
-      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == '/') ADVANCE(140);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '[') ADVANCE(132);
+      if (lookahead == '[') ADVANCE(133);
       if (lookahead == '{') ADVANCE(21);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(4)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       if (lookahead != 0 &&
           lookahead != '*' &&
-          lookahead != '}') ADVANCE(137);
+          lookahead != '}') ADVANCE(138);
       END_STATE();
     case 5:
       if (lookahead == '\n') SKIP(5)
-      if (lookahead == '#') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(131);
       if (lookahead == '*') SKIP(5)
-      if (lookahead == '.') ADVANCE(129);
-      if (lookahead == '/') ADVANCE(139);
-      if (lookahead == ':') ADVANCE(126);
+      if (lookahead == '.') ADVANCE(130);
+      if (lookahead == '/') ADVANCE(140);
+      if (lookahead == ':') ADVANCE(127);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '~') ADVANCE(131);
+      if (lookahead == '~') ADVANCE(132);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
       if ((11 <= lookahead && lookahead <= '\r')) SKIP(6)
       if (lookahead != 0 &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(137);
+          lookahead != '}') ADVANCE(138);
       END_STATE();
     case 6:
       if (lookahead == '\n') SKIP(5)
-      if (lookahead == '#') ADVANCE(130);
-      if (lookahead == '.') ADVANCE(129);
-      if (lookahead == '/') ADVANCE(139);
-      if (lookahead == ':') ADVANCE(126);
+      if (lookahead == '#') ADVANCE(131);
+      if (lookahead == '.') ADVANCE(130);
+      if (lookahead == '/') ADVANCE(140);
+      if (lookahead == ':') ADVANCE(127);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '~') ADVANCE(131);
+      if (lookahead == '~') ADVANCE(132);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(6)
       if (lookahead != 0 &&
           lookahead != '*' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(137);
+          lookahead != '}') ADVANCE(138);
       END_STATE();
     case 7:
       if (lookahead == '\n') SKIP(5)
-      if (lookahead == '#') ADVANCE(130);
-      if (lookahead == '.') ADVANCE(129);
-      if (lookahead == '/') ADVANCE(127);
-      if (lookahead == ':') ADVANCE(126);
+      if (lookahead == '#') ADVANCE(131);
+      if (lookahead == '.') ADVANCE(130);
+      if (lookahead == '/') ADVANCE(128);
+      if (lookahead == ':') ADVANCE(127);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '~') ADVANCE(131);
+      if (lookahead == '~') ADVANCE(132);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(6)
       if (lookahead != 0 &&
           lookahead != '*' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(137);
+          lookahead != '}') ADVANCE(138);
       END_STATE();
     case 8:
       if (lookahead == '\n') SKIP(8)
       if (lookahead == '*') SKIP(8)
-      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == '/') ADVANCE(140);
       if (lookahead == '@') ADVANCE(16);
       if (lookahead == '{') ADVANCE(21);
-      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '}') ADVANCE(26);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(8)
       if ((11 <= lookahead && lookahead <= '\r')) SKIP(9)
-      if (lookahead != 0) ADVANCE(137);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 9:
       if (lookahead == '\n') SKIP(8)
-      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == '/') ADVANCE(140);
       if (lookahead == '@') ADVANCE(16);
       if (lookahead == '{') ADVANCE(21);
-      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '}') ADVANCE(26);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(9)
       if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(137);
+          lookahead != '*') ADVANCE(138);
       END_STATE();
     case 10:
       if (lookahead == '\n') SKIP(10)
-      if (lookahead == '#') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(131);
       if (lookahead == '*') SKIP(10)
-      if (lookahead == '.') ADVANCE(129);
-      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == '.') ADVANCE(130);
+      if (lookahead == '/') ADVANCE(140);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '~') ADVANCE(131);
+      if (lookahead == '~') ADVANCE(132);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(10)
       if ((11 <= lookahead && lookahead <= '\r')) SKIP(11)
       if (lookahead != 0 &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(137);
+          lookahead != '}') ADVANCE(138);
       END_STATE();
     case 11:
       if (lookahead == '\n') SKIP(10)
-      if (lookahead == '#') ADVANCE(130);
-      if (lookahead == '.') ADVANCE(129);
-      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == '#') ADVANCE(131);
+      if (lookahead == '.') ADVANCE(130);
+      if (lookahead == '/') ADVANCE(140);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '~') ADVANCE(131);
+      if (lookahead == '~') ADVANCE(132);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(11)
       if (lookahead != 0 &&
           lookahead != '*' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(137);
+          lookahead != '}') ADVANCE(138);
       END_STATE();
     case 12:
       if (lookahead == '\n') SKIP(12)
@@ -491,7 +499,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') SKIP(12)
       if ((11 <= lookahead && lookahead <= '\r')) SKIP(13)
       if (lookahead != 0 &&
-          lookahead != '@') ADVANCE(137);
+          lookahead != '@') ADVANCE(138);
       END_STATE();
     case 13:
       if (lookahead == '\n') SKIP(12)
@@ -501,7 +509,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') SKIP(13)
       if (lookahead != 0 &&
           lookahead != '*' &&
-          lookahead != '@') ADVANCE(137);
+          lookahead != '@') ADVANCE(138);
       END_STATE();
     case 14:
       if (lookahead == '\n') ADVANCE(23);
@@ -512,77 +520,77 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '}') ADVANCE(25);
       END_STATE();
     case 15:
-      if (lookahead == '*') ADVANCE(136);
+      if (lookahead == '*') ADVANCE(137);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '{' &&
           lookahead != '}') ADVANCE(15);
       END_STATE();
     case 16:
-      if (lookahead == 'a') ADVANCE(42);
-      if (lookahead == 'b') ADVANCE(85);
-      if (lookahead == 'c') ADVANCE(32);
-      if (lookahead == 'e') ADVANCE(120);
-      if (lookahead == 'f') ADVANCE(65);
-      if (lookahead == 'm') ADVANCE(63);
-      if (lookahead == 'n') ADVANCE(33);
-      if (lookahead == 'p') ADVANCE(37);
-      if (lookahead == 'r') ADVANCE(49);
-      if (lookahead == 's') ADVANCE(35);
-      if (lookahead == 't') ADVANCE(62);
+      if (lookahead == 'a') ADVANCE(43);
+      if (lookahead == 'b') ADVANCE(86);
+      if (lookahead == 'c') ADVANCE(33);
+      if (lookahead == 'e') ADVANCE(121);
+      if (lookahead == 'f') ADVANCE(66);
+      if (lookahead == 'm') ADVANCE(64);
+      if (lookahead == 'n') ADVANCE(34);
+      if (lookahead == 'p') ADVANCE(38);
+      if (lookahead == 'r') ADVANCE(50);
+      if (lookahead == 's') ADVANCE(36);
+      if (lookahead == 't') ADVANCE(63);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('d' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('d' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 17:
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 18:
       if (eof) ADVANCE(20);
       if (lookahead == '\n') SKIP(18)
-      if (lookahead == '#') ADVANCE(130);
+      if (lookahead == '#') ADVANCE(131);
       if (lookahead == '*') SKIP(18)
-      if (lookahead == '.') ADVANCE(129);
-      if (lookahead == '/') ADVANCE(140);
-      if (lookahead == ':') ADVANCE(126);
+      if (lookahead == '.') ADVANCE(130);
+      if (lookahead == '/') ADVANCE(141);
+      if (lookahead == ':') ADVANCE(127);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '[') ADVANCE(132);
-      if (lookahead == ']') ADVANCE(133);
+      if (lookahead == '[') ADVANCE(133);
+      if (lookahead == ']') ADVANCE(134);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
-      if (lookahead == '~') ADVANCE(131);
+      if (lookahead == '~') ADVANCE(132);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(18)
       if ((11 <= lookahead && lookahead <= '\r')) SKIP(19)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      if (lookahead != 0) ADVANCE(137);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
+      if (lookahead != 0) ADVANCE(138);
       END_STATE();
     case 19:
       if (eof) ADVANCE(20);
       if (lookahead == '\n') SKIP(18)
-      if (lookahead == '#') ADVANCE(130);
-      if (lookahead == '.') ADVANCE(129);
-      if (lookahead == '/') ADVANCE(140);
-      if (lookahead == ':') ADVANCE(126);
+      if (lookahead == '#') ADVANCE(131);
+      if (lookahead == '.') ADVANCE(130);
+      if (lookahead == '/') ADVANCE(141);
+      if (lookahead == ':') ADVANCE(127);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '[') ADVANCE(132);
-      if (lookahead == ']') ADVANCE(133);
+      if (lookahead == '[') ADVANCE(133);
+      if (lookahead == ']') ADVANCE(134);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
-      if (lookahead == '~') ADVANCE(131);
+      if (lookahead == '~') ADVANCE(132);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(19)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(137);
+          lookahead != '*') ADVANCE(138);
       END_STATE();
     case 20:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -620,782 +628,785 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '}') ADVANCE(25);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(sym_tag_name_with_argument);
-      if (lookahead == 'e') ADVANCE(104);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token2);
       END_STATE();
     case 27:
       ACCEPT_TOKEN(sym_tag_name_with_argument);
-      if (lookahead == 's') ADVANCE(93);
+      if (lookahead == 'e') ADVANCE(105);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 28:
       ACCEPT_TOKEN(sym_tag_name_with_argument);
+      if (lookahead == 's') ADVANCE(94);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 29:
-      ACCEPT_TOKEN(sym_tag_name_with_type);
-      if (lookahead == 'd') ADVANCE(55);
+      ACCEPT_TOKEN(sym_tag_name_with_argument);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 30:
       ACCEPT_TOKEN(sym_tag_name_with_type);
-      if (lookahead == 's') ADVANCE(31);
+      if (lookahead == 'd') ADVANCE(56);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 31:
       ACCEPT_TOKEN(sym_tag_name_with_type);
+      if (lookahead == 's') ADVANCE(32);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 32:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(73);
-      if (lookahead == 'o') ADVANCE(78);
+      ACCEPT_TOKEN(sym_tag_name_with_type);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 33:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'a') ADVANCE(74);
+      if (lookahead == 'o') ADVANCE(79);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(126);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'a') ADVANCE(76);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(126);
+      END_STATE();
+    case 35:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'a') ADVANCE(75);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
-      END_STATE();
-    case 34:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(74);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
-      END_STATE();
-    case 35:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(114);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(43);
+      if (lookahead == 'a') ADVANCE(115);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(105);
-      if (lookahead == 'r') ADVANCE(87);
+      if (lookahead == 'a') ADVANCE(44);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(71);
+      if (lookahead == 'a') ADVANCE(106);
+      if (lookahead == 'r') ADVANCE(88);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(106);
+      if (lookahead == 'a') ADVANCE(72);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(46);
+      if (lookahead == 'a') ADVANCE(107);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'b') ADVANCE(36);
+      if (lookahead == 'a') ADVANCE(47);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(44);
-      if (lookahead == 'l') ADVANCE(66);
-      if (lookahead == 'p') ADVANCE(64);
-      if (lookahead == 'u') ADVANCE(61);
+      if (lookahead == 'b') ADVANCE(37);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(70);
+      if (lookahead == 'c') ADVANCE(45);
+      if (lookahead == 'l') ADVANCE(67);
+      if (lookahead == 'p') ADVANCE(65);
+      if (lookahead == 'u') ADVANCE(62);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(54);
+      if (lookahead == 'c') ADVANCE(71);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(117);
+      if (lookahead == 'c') ADVANCE(55);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(50);
+      if (lookahead == 'c') ADVANCE(118);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(115);
+      if (lookahead == 'c') ADVANCE(51);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'd') ADVANCE(106);
+      if (lookahead == 'c') ADVANCE(116);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(111);
+      if (lookahead == 'd') ADVANCE(107);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(28);
+      if (lookahead == 'e') ADVANCE(112);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 51:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(79);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
-      END_STATE();
-    case 52:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
-      END_STATE();
-    case 53:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'e') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
+      END_STATE();
+    case 52:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'e') ADVANCE(80);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'e') ADVANCE(28);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(109);
+      if (lookahead == 'e') ADVANCE(30);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(59);
+      if (lookahead == 'e') ADVANCE(110);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(82);
+      if (lookahead == 'e') ADVANCE(60);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(106);
+      if (lookahead == 'e') ADVANCE(83);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(84);
+      if (lookahead == 'e') ADVANCE(107);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'f') ADVANCE(28);
+      if (lookahead == 'e') ADVANCE(85);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'f') ADVANCE(69);
+      if (lookahead == 'f') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'g') ADVANCE(76);
+      if (lookahead == 'f') ADVANCE(70);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'h') ADVANCE(98);
-      if (lookahead == 'y') ADVANCE(94);
+      if (lookahead == 'g') ADVANCE(77);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(123);
+      if (lookahead == 'h') ADVANCE(99);
+      if (lookahead == 'y') ADVANCE(95);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(28);
+      if (lookahead == 'i') ADVANCE(124);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(100);
-      if (lookahead == 'u') ADVANCE(81);
+      if (lookahead == 'i') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(39);
+      if (lookahead == 'i') ADVANCE(101);
+      if (lookahead == 'u') ADVANCE(82);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(107);
+      if (lookahead == 'i') ADVANCE(40);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(90);
+      if (lookahead == 'i') ADVANCE(108);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(57);
+      if (lookahead == 'i') ADVANCE(91);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'k') ADVANCE(28);
+      if (lookahead == 'i') ADVANCE(58);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(28);
+      if (lookahead == 'k') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(41);
+      if (lookahead == 'l') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(72);
+      if (lookahead == 'l') ADVANCE(42);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(28);
+      if (lookahead == 'l') ADVANCE(73);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(52);
+      if (lookahead == 'm') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(58);
+      if (lookahead == 'm') ADVANCE(53);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 77:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(28);
+      if (lookahead == 'm') ADVANCE(59);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(108);
+      if (lookahead == 'n') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(48);
-      if (lookahead == 'r') ADVANCE(83);
+      if (lookahead == 'n') ADVANCE(109);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(30);
+      if (lookahead == 'n') ADVANCE(49);
+      if (lookahead == 'r') ADVANCE(84);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(47);
+      if (lookahead == 'n') ADVANCE(31);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(110);
+      if (lookahead == 'n') ADVANCE(48);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(38);
+      if (lookahead == 'n') ADVANCE(111);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(113);
+      if (lookahead == 'n') ADVANCE(39);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(101);
+      if (lookahead == 'n') ADVANCE(114);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 86:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(121);
+      if (lookahead == 'o') ADVANCE(102);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 87:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(92);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
-      END_STATE();
-    case 88:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'o') ADVANCE(122);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(93);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 89:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(103);
+      if (lookahead == 'o') ADVANCE(123);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 90:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(77);
+      if (lookahead == 'o') ADVANCE(104);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 91:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(96);
+      if (lookahead == 'o') ADVANCE(78);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(26);
+      if (lookahead == 'o') ADVANCE(97);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(40);
+      if (lookahead == 'p') ADVANCE(27);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(53);
+      if (lookahead == 'p') ADVANCE(41);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(89);
-      if (lookahead == 't') ADVANCE(51);
+      if (lookahead == 'p') ADVANCE(54);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(28);
+      if (lookahead == 'p') ADVANCE(90);
+      if (lookahead == 't') ADVANCE(52);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(119);
+      if (lookahead == 'r') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(86);
+      if (lookahead == 'r') ADVANCE(120);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 99:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(88);
+      if (lookahead == 'r') ADVANCE(87);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(57);
+      if (lookahead == 'r') ADVANCE(89);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(99);
+      if (lookahead == 'r') ADVANCE(58);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(80);
+      if (lookahead == 'r') ADVANCE(100);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 103:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(81);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
+      END_STATE();
+    case 104:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(114);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
+      END_STATE();
+    case 105:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'r') ADVANCE(113);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
-      END_STATE();
-    case 104:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(112);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
-      END_STATE();
-    case 105:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(34);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 's') ADVANCE(28);
+      if (lookahead == 'r') ADVANCE(35);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 's') ADVANCE(60);
+      if (lookahead == 's') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 's') ADVANCE(116);
+      if (lookahead == 's') ADVANCE(61);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 's') ADVANCE(106);
+      if (lookahead == 's') ADVANCE(117);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(28);
+      if (lookahead == 's') ADVANCE(107);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(118);
+      if (lookahead == 't') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(124);
+      if (lookahead == 't') ADVANCE(119);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(106);
+      if (lookahead == 't') ADVANCE(125);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(67);
+      if (lookahead == 't') ADVANCE(107);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 't') ADVANCE(68);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 116:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(97);
+      if (lookahead == 't') ADVANCE(69);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(91);
+      if (lookahead == 't') ADVANCE(98);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'u') ADVANCE(102);
+      if (lookahead == 't') ADVANCE(92);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'u') ADVANCE(45);
+      if (lookahead == 'u') ADVANCE(103);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'v') ADVANCE(56);
-      if (lookahead == 'x') ADVANCE(95);
+      if (lookahead == 'u') ADVANCE(46);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'w') ADVANCE(30);
+      if (lookahead == 'v') ADVANCE(57);
+      if (lookahead == 'x') ADVANCE(96);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'w') ADVANCE(106);
+      if (lookahead == 'w') ADVANCE(31);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'x') ADVANCE(57);
+      if (lookahead == 'w') ADVANCE(107);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'y') ADVANCE(28);
+      if (lookahead == 'x') ADVANCE(58);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'y') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 126:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
     case 127:
-      ACCEPT_TOKEN(anon_sym_SLASH);
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(anon_sym_SLASH);
-      if (lookahead == '*') ADVANCE(138);
       END_STATE();
     case 129:
-      ACCEPT_TOKEN(anon_sym_DOT);
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      if (lookahead == '*') ADVANCE(139);
       END_STATE();
     case 130:
-      ACCEPT_TOKEN(anon_sym_POUND);
+      ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
     case 131:
-      ACCEPT_TOKEN(anon_sym_TILDE);
+      ACCEPT_TOKEN(anon_sym_POUND);
       END_STATE();
     case 132:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      ACCEPT_TOKEN(anon_sym_TILDE);
       END_STATE();
     case 133:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 134:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      END_STATE();
+    case 135:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == '$' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
-      END_STATE();
-    case 135:
-      ACCEPT_TOKEN(sym__text);
-      if (lookahead == '*') ADVANCE(136);
-      if (lookahead == '/') ADVANCE(135);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(sym__text);
-      if (lookahead == '*') ADVANCE(136);
+      if (lookahead == '*') ADVANCE(137);
+      if (lookahead == '/') ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(136);
+      END_STATE();
+    case 137:
+      ACCEPT_TOKEN(sym__text);
+      if (lookahead == '*') ADVANCE(137);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '/' &&
           lookahead != '{' &&
           lookahead != '}') ADVANCE(15);
       END_STATE();
-    case 137:
+    case 138:
       ACCEPT_TOKEN(sym__text);
-      if (lookahead == '/') ADVANCE(137);
+      if (lookahead == '/') ADVANCE(138);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '*' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(135);
-      END_STATE();
-    case 138:
-      ACCEPT_TOKEN(sym__begin);
-      if (lookahead == '*') ADVANCE(138);
+          lookahead != '}') ADVANCE(136);
       END_STATE();
     case 139:
-      ACCEPT_TOKEN(sym__end);
+      ACCEPT_TOKEN(sym__begin);
+      if (lookahead == '*') ADVANCE(139);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(sym__end);
-      if (lookahead == '*') ADVANCE(138);
+      END_STATE();
+    case 141:
+      ACCEPT_TOKEN(sym__end);
+      if (lookahead == '*') ADVANCE(139);
       END_STATE();
     default:
       return false;
@@ -1436,27 +1447,28 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [30] = {.lex_state = 4},
   [31] = {.lex_state = 4},
   [32] = {.lex_state = 4},
-  [33] = {.lex_state = 4},
-  [34] = {.lex_state = 13},
+  [33] = {.lex_state = 13},
+  [34] = {.lex_state = 4},
   [35] = {.lex_state = 13},
   [36] = {.lex_state = 13},
-  [37] = {.lex_state = 14},
-  [38] = {.lex_state = 0},
-  [39] = {.lex_state = 13},
-  [40] = {.lex_state = 14},
-  [41] = {.lex_state = 0},
+  [37] = {.lex_state = 13},
+  [38] = {.lex_state = 14},
+  [39] = {.lex_state = 0},
+  [40] = {.lex_state = 13},
+  [41] = {.lex_state = 14},
   [42] = {.lex_state = 0},
   [43] = {.lex_state = 0},
   [44] = {.lex_state = 0, .external_lex_state = 1},
   [45] = {.lex_state = 0},
   [46] = {.lex_state = 0},
   [47] = {.lex_state = 0, .external_lex_state = 1},
-  [48] = {.lex_state = 2},
+  [48] = {.lex_state = 0},
   [49] = {.lex_state = 0},
   [50] = {.lex_state = 0},
-  [51] = {.lex_state = 0},
+  [51] = {.lex_state = 2},
   [52] = {.lex_state = 0},
   [53] = {.lex_state = 0},
+  [54] = {.lex_state = 0},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1464,6 +1476,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [ts_builtin_sym_end] = ACTIONS(1),
     [anon_sym_LBRACE] = ACTIONS(1),
     [anon_sym_RBRACE] = ACTIONS(1),
+    [aux_sym__inline_tag_false_positive_token2] = ACTIONS(1),
     [sym_tag_name_with_argument] = ACTIONS(1),
     [sym_tag_name_with_type] = ACTIONS(1),
     [sym_tag_name] = ACTIONS(1),
@@ -1481,7 +1494,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_type] = ACTIONS(1),
   },
   [1] = {
-    [sym_document] = STATE(51),
+    [sym_document] = STATE(52),
     [sym__begin] = ACTIONS(3),
   },
 };
@@ -1519,7 +1532,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text,
     ACTIONS(19), 1,
       sym__end,
-    STATE(33), 1,
+    STATE(31), 1,
       sym_description,
     ACTIONS(17), 3,
       sym_tag_name_with_argument,
@@ -1566,7 +1579,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text,
     ACTIONS(41), 1,
       sym__end,
-    STATE(32), 1,
+    STATE(34), 1,
       sym_description,
     ACTIONS(37), 3,
       sym_tag_name_with_argument,
@@ -1624,7 +1637,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text,
     ACTIONS(65), 1,
       sym__end,
-    STATE(31), 1,
+    STATE(32), 1,
       sym_description,
     ACTIONS(39), 3,
       anon_sym_DOT,
@@ -1720,7 +1733,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tag_name,
   [301] = 3,
     ACTIONS(91), 1,
-      anon_sym_RBRACE,
+      aux_sym__inline_tag_false_positive_token2,
     ACTIONS(89), 2,
       anon_sym_LBRACE,
       sym__end,
@@ -1743,7 +1756,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text,
     ACTIONS(19), 1,
       sym__end,
-    STATE(33), 1,
+    STATE(31), 1,
       sym_description,
     ACTIONS(17), 3,
       sym_tag_name_with_argument,
@@ -1858,99 +1871,106 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tag_name_with_type,
       sym_tag_name,
   [489] = 2,
-    ACTIONS(132), 1,
-      sym__end,
-    ACTIONS(130), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-  [498] = 2,
-    ACTIONS(136), 1,
-      sym__end,
-    ACTIONS(134), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-  [507] = 2,
     ACTIONS(41), 1,
       sym__end,
     ACTIONS(37), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-  [516] = 1,
-    ACTIONS(112), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      sym__text,
-  [522] = 1,
+  [498] = 2,
+    ACTIONS(132), 1,
+      sym__end,
+    ACTIONS(130), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [507] = 2,
+    ACTIONS(134), 1,
+      aux_sym__inline_tag_false_positive_token2,
     ACTIONS(89), 3,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       sym__text,
-  [528] = 2,
+  [516] = 2,
     ACTIONS(138), 1,
-      sym__text,
-    STATE(52), 1,
-      sym_description,
-  [535] = 2,
-    ACTIONS(140), 1,
-      aux_sym__inline_tag_false_positive_token1,
-    ACTIONS(142), 1,
+      sym__end,
+    ACTIONS(136), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
       sym_tag_name,
-  [542] = 2,
+  [525] = 1,
+    ACTIONS(112), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      sym__text,
+  [531] = 1,
+    ACTIONS(95), 3,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      sym__text,
+  [537] = 2,
+    ACTIONS(140), 1,
+      sym__text,
+    STATE(53), 1,
+      sym_description,
+  [544] = 2,
+    ACTIONS(142), 1,
+      aux_sym__inline_tag_false_positive_token1,
     ACTIONS(144), 1,
+      sym_tag_name,
+  [551] = 2,
+    ACTIONS(146), 1,
       sym_identifier,
     STATE(15), 1,
       sym_qualified_expression,
-  [549] = 2,
-    ACTIONS(138), 1,
+  [558] = 2,
+    ACTIONS(140), 1,
       sym__text,
-    STATE(41), 1,
+    STATE(45), 1,
       sym_description,
-  [556] = 2,
-    ACTIONS(146), 1,
-      aux_sym__inline_tag_false_positive_token1,
+  [565] = 2,
     ACTIONS(148), 1,
-      sym_tag_name,
-  [563] = 1,
+      aux_sym__inline_tag_false_positive_token1,
     ACTIONS(150), 1,
-      anon_sym_RBRACE,
-  [567] = 1,
+      sym_tag_name,
+  [572] = 1,
     ACTIONS(152), 1,
-      ts_builtin_sym_end,
-  [571] = 1,
+      sym_identifier,
+  [576] = 1,
     ACTIONS(154), 1,
       ts_builtin_sym_end,
-  [575] = 1,
+  [580] = 1,
     ACTIONS(156), 1,
       sym_type,
-  [579] = 1,
+  [584] = 1,
     ACTIONS(158), 1,
       anon_sym_RBRACE,
-  [583] = 1,
+  [588] = 1,
     ACTIONS(160), 1,
       sym_identifier,
-  [587] = 1,
+  [592] = 1,
     ACTIONS(162), 1,
       sym_type,
-  [591] = 1,
+  [596] = 1,
     ACTIONS(164), 1,
-      anon_sym_RBRACK,
-  [595] = 1,
+      ts_builtin_sym_end,
+  [600] = 1,
     ACTIONS(166), 1,
       ts_builtin_sym_end,
-  [599] = 1,
+  [604] = 1,
     ACTIONS(168), 1,
-      sym_identifier,
-  [603] = 1,
-    ACTIONS(170), 1,
-      ts_builtin_sym_end,
-  [607] = 1,
-    ACTIONS(172), 1,
       anon_sym_RBRACE,
-  [611] = 1,
+  [608] = 1,
+    ACTIONS(170), 1,
+      anon_sym_RBRACK,
+  [612] = 1,
+    ACTIONS(172), 1,
+      ts_builtin_sym_end,
+  [616] = 1,
     ACTIONS(174), 1,
+      anon_sym_RBRACE,
+  [620] = 1,
+    ACTIONS(176), 1,
       anon_sym_RBRACE,
 };
 
@@ -1988,25 +2008,26 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(32)] = 498,
   [SMALL_STATE(33)] = 507,
   [SMALL_STATE(34)] = 516,
-  [SMALL_STATE(35)] = 522,
-  [SMALL_STATE(36)] = 528,
-  [SMALL_STATE(37)] = 535,
-  [SMALL_STATE(38)] = 542,
-  [SMALL_STATE(39)] = 549,
-  [SMALL_STATE(40)] = 556,
-  [SMALL_STATE(41)] = 563,
-  [SMALL_STATE(42)] = 567,
-  [SMALL_STATE(43)] = 571,
-  [SMALL_STATE(44)] = 575,
-  [SMALL_STATE(45)] = 579,
-  [SMALL_STATE(46)] = 583,
-  [SMALL_STATE(47)] = 587,
-  [SMALL_STATE(48)] = 591,
-  [SMALL_STATE(49)] = 595,
-  [SMALL_STATE(50)] = 599,
-  [SMALL_STATE(51)] = 603,
-  [SMALL_STATE(52)] = 607,
-  [SMALL_STATE(53)] = 611,
+  [SMALL_STATE(35)] = 525,
+  [SMALL_STATE(36)] = 531,
+  [SMALL_STATE(37)] = 537,
+  [SMALL_STATE(38)] = 544,
+  [SMALL_STATE(39)] = 551,
+  [SMALL_STATE(40)] = 558,
+  [SMALL_STATE(41)] = 565,
+  [SMALL_STATE(42)] = 572,
+  [SMALL_STATE(43)] = 576,
+  [SMALL_STATE(44)] = 580,
+  [SMALL_STATE(45)] = 584,
+  [SMALL_STATE(46)] = 588,
+  [SMALL_STATE(47)] = 592,
+  [SMALL_STATE(48)] = 596,
+  [SMALL_STATE(49)] = 600,
+  [SMALL_STATE(50)] = 604,
+  [SMALL_STATE(51)] = 608,
+  [SMALL_STATE(52)] = 612,
+  [SMALL_STATE(53)] = 616,
+  [SMALL_STATE(54)] = 620,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -2023,16 +2044,16 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 4),
   [21] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression, 1),
   [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
   [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
   [31] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_description, 1),
   [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
   [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_description, 1),
   [37] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 5),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
   [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 5),
-  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(40),
+  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(41),
   [46] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2),
   [48] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(7),
   [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2),
@@ -2066,35 +2087,36 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
   [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_tag, 4),
   [114] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_tag, 4),
-  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
   [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(37),
+  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(38),
   [123] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(25),
-  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
   [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
   [130] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
   [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
-  [134] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 6),
-  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 6),
-  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [142] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
-  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [148] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
-  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3),
+  [134] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
+  [136] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 6),
+  [138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 6),
+  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [144] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
+  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [150] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
+  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
   [154] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 4),
-  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
-  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3),
   [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2),
-  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [170] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [172] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
 };
 
 enum ts_external_scanner_symbol_identifiers {

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,12 +6,12 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 51
+#define STATE_COUNT 54
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 29
+#define SYMBOL_COUNT 31
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 18
-#define EXTERNAL_TOKEN_COUNT 0
+#define TOKEN_COUNT 19
+#define EXTERNAL_TOKEN_COUNT 1
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
 #define PRODUCTION_ID_COUNT 1
@@ -19,38 +19,41 @@
 enum ts_symbol_identifiers {
   anon_sym_LBRACE = 1,
   anon_sym_RBRACE = 2,
-  sym_tag_name_with_argument = 3,
-  sym_tag_name_with_type = 4,
-  sym_tag_name = 5,
-  anon_sym_COLON = 6,
-  anon_sym_SLASH = 7,
-  anon_sym_DOT = 8,
-  anon_sym_POUND = 9,
-  anon_sym_TILDE = 10,
-  anon_sym_LBRACK = 11,
-  anon_sym_RBRACK = 12,
-  sym_identifier = 13,
-  sym_type = 14,
+  aux_sym__inline_tag_false_positive_token1 = 3,
+  sym_tag_name_with_argument = 4,
+  sym_tag_name_with_type = 5,
+  sym_tag_name = 6,
+  anon_sym_COLON = 7,
+  anon_sym_SLASH = 8,
+  anon_sym_DOT = 9,
+  anon_sym_POUND = 10,
+  anon_sym_TILDE = 11,
+  anon_sym_LBRACK = 12,
+  anon_sym_RBRACK = 13,
+  sym_identifier = 14,
   sym__text = 15,
   sym__begin = 16,
   sym__end = 17,
-  sym_document = 18,
-  sym_description = 19,
-  sym_tag = 20,
-  sym_inline_tag = 21,
-  sym__expression = 22,
-  sym_qualified_expression = 23,
-  sym_path_expression = 24,
-  sym_member_expression = 25,
-  sym_optional_identifier = 26,
-  aux_sym_document_repeat1 = 27,
-  aux_sym_description_repeat1 = 28,
+  sym_type = 18,
+  sym_document = 19,
+  sym_description = 20,
+  sym_tag = 21,
+  sym_inline_tag = 22,
+  sym__inline_tag_false_positive = 23,
+  sym__expression = 24,
+  sym_qualified_expression = 25,
+  sym_path_expression = 26,
+  sym_member_expression = 27,
+  sym_optional_identifier = 28,
+  aux_sym_document_repeat1 = 29,
+  aux_sym_description_repeat1 = 30,
 };
 
 static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [anon_sym_LBRACE] = "{",
   [anon_sym_RBRACE] = "}",
+  [aux_sym__inline_tag_false_positive_token1] = "_inline_tag_false_positive_token1",
   [sym_tag_name_with_argument] = "tag_name",
   [sym_tag_name_with_type] = "tag_name",
   [sym_tag_name] = "tag_name",
@@ -62,14 +65,15 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_LBRACK] = "[",
   [anon_sym_RBRACK] = "]",
   [sym_identifier] = "identifier",
-  [sym_type] = "type",
   [sym__text] = "_text",
   [sym__begin] = "_begin",
   [sym__end] = "_end",
+  [sym_type] = "type",
   [sym_document] = "document",
   [sym_description] = "description",
   [sym_tag] = "tag",
   [sym_inline_tag] = "inline_tag",
+  [sym__inline_tag_false_positive] = "_inline_tag_false_positive",
   [sym__expression] = "_expression",
   [sym_qualified_expression] = "qualified_expression",
   [sym_path_expression] = "path_expression",
@@ -83,6 +87,7 @@ static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [anon_sym_LBRACE] = anon_sym_LBRACE,
   [anon_sym_RBRACE] = anon_sym_RBRACE,
+  [aux_sym__inline_tag_false_positive_token1] = aux_sym__inline_tag_false_positive_token1,
   [sym_tag_name_with_argument] = sym_tag_name,
   [sym_tag_name_with_type] = sym_tag_name,
   [sym_tag_name] = sym_tag_name,
@@ -94,14 +99,15 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_LBRACK] = anon_sym_LBRACK,
   [anon_sym_RBRACK] = anon_sym_RBRACK,
   [sym_identifier] = sym_identifier,
-  [sym_type] = sym_type,
   [sym__text] = sym__text,
   [sym__begin] = sym__begin,
   [sym__end] = sym__end,
+  [sym_type] = sym_type,
   [sym_document] = sym_document,
   [sym_description] = sym_description,
   [sym_tag] = sym_tag,
   [sym_inline_tag] = sym_inline_tag,
+  [sym__inline_tag_false_positive] = sym__inline_tag_false_positive,
   [sym__expression] = sym__expression,
   [sym_qualified_expression] = sym_qualified_expression,
   [sym_path_expression] = sym_path_expression,
@@ -122,6 +128,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
   [anon_sym_RBRACE] = {
     .visible = true,
+    .named = false,
+  },
+  [aux_sym__inline_tag_false_positive_token1] = {
+    .visible = false,
     .named = false,
   },
   [sym_tag_name_with_argument] = {
@@ -168,10 +178,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym_type] = {
-    .visible = true,
-    .named = true,
-  },
   [sym__text] = {
     .visible = false,
     .named = true,
@@ -182,6 +188,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
   [sym__end] = {
     .visible = false,
+    .named = true,
+  },
+  [sym_type] = {
+    .visible = true,
     .named = true,
   },
   [sym_document] = {
@@ -198,6 +208,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
   [sym_inline_tag] = {
     .visible = true,
+    .named = true,
+  },
+  [sym__inline_tag_false_positive] = {
+    .visible = false,
     .named = true,
   },
   [sym__expression] = {
@@ -263,23 +277,23 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [21] = 21,
   [22] = 22,
   [23] = 23,
-  [24] = 24,
-  [25] = 11,
-  [26] = 8,
-  [27] = 15,
-  [28] = 28,
+  [24] = 5,
+  [25] = 7,
+  [26] = 26,
+  [27] = 27,
+  [28] = 9,
   [29] = 29,
   [30] = 30,
   [31] = 31,
-  [32] = 21,
+  [32] = 32,
   [33] = 33,
-  [34] = 34,
-  [35] = 33,
+  [34] = 23,
+  [35] = 18,
   [36] = 36,
   [37] = 37,
   [38] = 38,
-  [39] = 39,
-  [40] = 40,
+  [39] = 36,
+  [40] = 37,
   [41] = 41,
   [42] = 42,
   [43] = 43,
@@ -287,9 +301,12 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [45] = 45,
   [46] = 46,
   [47] = 47,
-  [48] = 39,
+  [48] = 48,
   [49] = 49,
-  [50] = 45,
+  [50] = 50,
+  [51] = 51,
+  [52] = 41,
+  [53] = 53,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -297,6 +314,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
+<<<<<<< HEAD
       if (eof) ADVANCE(21);
       if (lookahead == '\n') SKIP(19)
       if (lookahead == '#') ADVANCE(128);
@@ -317,38 +335,81 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
       if (lookahead != 0 &&
           lookahead != '*') ADVANCE(138);
+=======
+      if (eof) ADVANCE(20);
+      if (lookahead == '\n') SKIP(18)
+      if (lookahead == '#') ADVANCE(120);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(118);
+      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '[') ADVANCE(122);
+      if (lookahead == ']') ADVANCE(123);
+      if (lookahead == '{') ADVANCE(21);
+      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '~') ADVANCE(121);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(19)
+      if (lookahead == '$' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
+      if (lookahead != 0 &&
+          lookahead != '*') ADVANCE(127);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 1:
       if (lookahead == '\n') SKIP(1)
+      if (lookahead == '\r') SKIP(2)
       if (lookahead == '*') SKIP(1)
+<<<<<<< HEAD
       if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(18);
       if (lookahead == ']') ADVANCE(131);
+=======
+      if (lookahead == '/') ADVANCE(128);
+      if (lookahead == ']') ADVANCE(123);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(1)
-      if ((11 <= lookahead && lookahead <= '\r')) SKIP(2)
       END_STATE();
     case 2:
       if (lookahead == '\n') SKIP(1)
+<<<<<<< HEAD
       if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(18);
       if (lookahead == ']') ADVANCE(131);
       if (('\t' <= lookahead && lookahead <= '\r') ||
+=======
+      if (lookahead == '/') ADVANCE(128);
+      if (lookahead == ']') ADVANCE(123);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+>>>>>>> 5ee169e (Permit braces in more contexts)
           lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
       if (lookahead == '\n') SKIP(3)
+      if (lookahead == '\r') SKIP(4)
       if (lookahead == '*') SKIP(3)
+<<<<<<< HEAD
       if (lookahead == '/') ADVANCE(140);
       if (lookahead == '@') ADVANCE(17);
       if (lookahead == '[') ADVANCE(130);
       if (lookahead == '{') ADVANCE(22);
+=======
+      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '[') ADVANCE(122);
+      if (lookahead == '{') ADVANCE(21);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(3)
-      if ((11 <= lookahead && lookahead <= '\r')) SKIP(4)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+<<<<<<< HEAD
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
       if (lookahead != 0 &&
           lookahead != '}') ADVANCE(138);
@@ -360,10 +421,25 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '[') ADVANCE(130);
       if (lookahead == '{') ADVANCE(22);
       if (('\t' <= lookahead && lookahead <= '\r') ||
+=======
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
+      if (lookahead != 0 &&
+          lookahead != '}') ADVANCE(127);
+      END_STATE();
+    case 4:
+      if (lookahead == '\n') SKIP(3)
+      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '[') ADVANCE(122);
+      if (lookahead == '{') ADVANCE(21);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+>>>>>>> 5ee169e (Permit braces in more contexts)
           lookahead == ' ') SKIP(4)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+<<<<<<< HEAD
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
       if (lookahead != 0 &&
           lookahead != '*' &&
@@ -378,11 +454,28 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == ':') ADVANCE(124);
       if (lookahead == '@') ADVANCE(17);
       if (lookahead == '~') ADVANCE(129);
+=======
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
+      if (lookahead != 0 &&
+          lookahead != '*' &&
+          lookahead != '}') ADVANCE(127);
+      END_STATE();
+    case 5:
+      if (lookahead == '\n') SKIP(5)
+      if (lookahead == '\r') SKIP(6)
+      if (lookahead == '#') ADVANCE(120);
+      if (lookahead == '*') SKIP(5)
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '~') ADVANCE(121);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
-      if ((11 <= lookahead && lookahead <= '\r')) SKIP(6)
       if (lookahead != 0 &&
           lookahead != '{' &&
+<<<<<<< HEAD
           lookahead != '}') ADVANCE(138);
       END_STATE();
     case 6:
@@ -394,10 +487,25 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '@') ADVANCE(17);
       if (lookahead == '~') ADVANCE(129);
       if (('\t' <= lookahead && lookahead <= '\r') ||
+=======
+          lookahead != '}') ADVANCE(127);
+      END_STATE();
+    case 6:
+      if (lookahead == '\n') SKIP(5)
+      if (lookahead == '#') ADVANCE(120);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '~') ADVANCE(121);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+>>>>>>> 5ee169e (Permit braces in more contexts)
           lookahead == ' ') SKIP(6)
       if (lookahead != 0 &&
           lookahead != '*' &&
           lookahead != '{' &&
+<<<<<<< HEAD
           lookahead != '}') ADVANCE(138);
       END_STATE();
     case 7:
@@ -409,10 +517,25 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '@') ADVANCE(17);
       if (lookahead == '~') ADVANCE(129);
       if (('\t' <= lookahead && lookahead <= '\r') ||
+=======
+          lookahead != '}') ADVANCE(127);
+      END_STATE();
+    case 7:
+      if (lookahead == '\n') SKIP(5)
+      if (lookahead == '#') ADVANCE(120);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(117);
+      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '~') ADVANCE(121);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+>>>>>>> 5ee169e (Permit braces in more contexts)
           lookahead == ' ') SKIP(6)
       if (lookahead != 0 &&
           lookahead != '*' &&
           lookahead != '{' &&
+<<<<<<< HEAD
           lookahead != '}') ADVANCE(138);
       END_STATE();
     case 8:
@@ -443,17 +566,53 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '*' &&
           lookahead != '{' &&
           lookahead != '}') ADVANCE(138);
+=======
+          lookahead != '}') ADVANCE(127);
+      END_STATE();
+    case 8:
+      if (lookahead == '\n') SKIP(8)
+      if (lookahead == '\r') SKIP(9)
+      if (lookahead == '*') SKIP(8)
+      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '{') ADVANCE(21);
+      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(8)
+      if (lookahead != 0) ADVANCE(127);
+      END_STATE();
+    case 9:
+      if (lookahead == '\n') SKIP(8)
+      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '{') ADVANCE(21);
+      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(9)
+      if (lookahead != 0 &&
+          lookahead != '*') ADVANCE(127);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 10:
       if (lookahead == '\n') SKIP(10)
+      if (lookahead == '\r') SKIP(11)
+      if (lookahead == '#') ADVANCE(120);
       if (lookahead == '*') SKIP(10)
+<<<<<<< HEAD
       if (lookahead == '/') ADVANCE(140);
       if (lookahead == '@') ADVANCE(17);
       if (lookahead == '{') ADVANCE(22);
+=======
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '~') ADVANCE(121);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(10)
-      if ((11 <= lookahead && lookahead <= '\r')) SKIP(11)
       if (lookahead != 0 &&
+<<<<<<< HEAD
           lookahead != '}') ADVANCE(138);
       END_STATE();
     case 11:
@@ -466,26 +625,51 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '*' &&
           lookahead != '}') ADVANCE(138);
+=======
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(127);
+      END_STATE();
+    case 11:
+      if (lookahead == '\n') SKIP(10)
+      if (lookahead == '#') ADVANCE(120);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '~') ADVANCE(121);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(11)
+      if (lookahead != 0 &&
+          lookahead != '*' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(127);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 12:
       if (lookahead == '\n') SKIP(12)
+      if (lookahead == '\r') SKIP(13)
       if (lookahead == '*') SKIP(12)
-      if (lookahead == '{') ADVANCE(22);
-      if (lookahead == '}') ADVANCE(23);
+      if (lookahead == '{') ADVANCE(21);
+      if (lookahead == '}') ADVANCE(22);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(12)
-      if ((11 <= lookahead && lookahead <= '\r')) SKIP(13)
       if (lookahead != 0 &&
+<<<<<<< HEAD
           lookahead != '@') ADVANCE(138);
+=======
+          lookahead != '@') ADVANCE(127);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 13:
       if (lookahead == '\n') SKIP(12)
-      if (lookahead == '{') ADVANCE(22);
-      if (lookahead == '}') ADVANCE(23);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
+      if (lookahead == '{') ADVANCE(21);
+      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
           lookahead == ' ') SKIP(13)
       if (lookahead != 0 &&
           lookahead != '*' &&
+<<<<<<< HEAD
           lookahead != '@') ADVANCE(138);
       END_STATE();
     case 14:
@@ -506,12 +690,43 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 16:
       if (lookahead == '*') ADVANCE(137);
+=======
+          lookahead != '@') ADVANCE(127);
+      END_STATE();
+    case 14:
+      if (lookahead == '\n') ADVANCE(23);
+      if (lookahead == '@') ADVANCE(17);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(24);
+      if (lookahead != 0 &&
+          lookahead != '}') ADVANCE(25);
+      END_STATE();
+    case 15:
+      if (lookahead == '*') ADVANCE(126);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(16);
+          lookahead != '}') ADVANCE(15);
+      END_STATE();
+    case 16:
+      if (lookahead == 'a') ADVANCE(39);
+      if (lookahead == 'b') ADVANCE(76);
+      if (lookahead == 'c') ADVANCE(30);
+      if (lookahead == 'e') ADVANCE(110);
+      if (lookahead == 'f') ADVANCE(60);
+      if (lookahead == 'm') ADVANCE(57);
+      if (lookahead == 'n') ADVANCE(31);
+      if (lookahead == 'p') ADVANCE(34);
+      if (lookahead == 'r') ADVANCE(45);
+      if (lookahead == 't') ADVANCE(56);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('d' <= lookahead && lookahead <= 'z')) ADVANCE(115);
       END_STATE();
     case 17:
+<<<<<<< HEAD
       if (lookahead == 'a') ADVANCE(39);
       if (lookahead == 'b') ADVANCE(83);
       if (lookahead == 'c') ADVANCE(29);
@@ -526,10 +741,33 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('d' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 18:
+=======
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
+      END_STATE();
+    case 18:
+      if (eof) ADVANCE(20);
+      if (lookahead == '\n') SKIP(18)
+      if (lookahead == '\r') SKIP(19)
+      if (lookahead == '#') ADVANCE(120);
+      if (lookahead == '*') SKIP(18)
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(130);
+      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '[') ADVANCE(122);
+      if (lookahead == ']') ADVANCE(123);
+      if (lookahead == '{') ADVANCE(21);
+      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '~') ADVANCE(121);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(18)
+      if (lookahead == '$' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+<<<<<<< HEAD
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
       END_STATE();
     case 19:
@@ -546,12 +784,31 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '{') ADVANCE(22);
       if (lookahead == '}') ADVANCE(23);
       if (lookahead == '~') ADVANCE(129);
+=======
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
+      if (lookahead != 0) ADVANCE(127);
+      END_STATE();
+    case 19:
+      if (eof) ADVANCE(20);
+      if (lookahead == '\n') SKIP(18)
+      if (lookahead == '#') ADVANCE(120);
+      if (lookahead == '.') ADVANCE(119);
+      if (lookahead == '/') ADVANCE(130);
+      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '[') ADVANCE(122);
+      if (lookahead == ']') ADVANCE(123);
+      if (lookahead == '{') ADVANCE(21);
+      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '~') ADVANCE(121);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       if (lookahead == '\t' ||
+          lookahead == '\r' ||
           lookahead == ' ') SKIP(19)
-      if ((11 <= lookahead && lookahead <= '\r')) SKIP(20)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+<<<<<<< HEAD
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
       if (lookahead != 0) ADVANCE(138);
       END_STATE();
@@ -578,26 +835,69 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '*') ADVANCE(138);
       END_STATE();
     case 21:
+=======
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
+      if (lookahead != 0 &&
+          lookahead != '*') ADVANCE(127);
+      END_STATE();
+    case 20:
+>>>>>>> 5ee169e (Permit braces in more contexts)
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 22:
+    case 21:
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
-    case 23:
+    case 22:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
+    case 23:
+      ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token1);
+      if (lookahead == '\n') ADVANCE(23);
+      if (lookahead == '\r') ADVANCE(24);
+      if (lookahead == '*') ADVANCE(23);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(23);
+      if (lookahead != 0 &&
+          lookahead != '@' &&
+          lookahead != '}') ADVANCE(25);
+      END_STATE();
     case 24:
+<<<<<<< HEAD
       ACCEPT_TOKEN(sym_tag_name_with_argument);
       if (lookahead == 'e') ADVANCE(102);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+      ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token1);
+      if (lookahead == '\n') ADVANCE(23);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(24);
+      if (lookahead != 0 &&
+          lookahead != '@' &&
+          lookahead != '}') ADVANCE(25);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 25:
+      ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token1);
+      if (lookahead != 0 &&
+          lookahead != '@' &&
+          lookahead != '}') ADVANCE(25);
+      END_STATE();
+    case 26:
+      ACCEPT_TOKEN(sym_tag_name_with_argument);
+      if (lookahead == 's') ADVANCE(83);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 27:
       ACCEPT_TOKEN(sym_tag_name_with_argument);
       if (lookahead == 's') ADVANCE(91);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+<<<<<<< HEAD
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
       END_STATE();
     case 26:
@@ -683,54 +983,223 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('b' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 28:
+      ACCEPT_TOKEN(sym_tag_name_with_type);
+      if (lookahead == 's') ADVANCE(29);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 29:
+      ACCEPT_TOKEN(sym_tag_name_with_type);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 30:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'a') ADVANCE(65);
+      if (lookahead == 'o') ADVANCE(70);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 31:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'a') ADVANCE(67);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'a') ADVANCE(66);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 33:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'a') ADVANCE(40);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'a') ADVANCE(97);
+      if (lookahead == 'r') ADVANCE(82);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'a') ADVANCE(63);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 36:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'a') ADVANCE(98);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 37:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'a') ADVANCE(44);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 38:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'b') ADVANCE(33);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+<<<<<<< HEAD
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 39:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'c') ADVANCE(41);
+<<<<<<< HEAD
       if (lookahead == 'l') ADVANCE(64);
       if (lookahead == 'p') ADVANCE(62);
       if (lookahead == 'u') ADVANCE(59);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+      if (lookahead == 'l') ADVANCE(59);
+      if (lookahead == 'p') ADVANCE(58);
+      if (lookahead == 'u') ADVANCE(55);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'c') ADVANCE(62);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 41:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'c') ADVANCE(49);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 42:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'c') ADVANCE(105);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 43:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'c') ADVANCE(107);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 44:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'c') ADVANCE(46);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
+      END_STATE();
+    case 45:
+      ACCEPT_TOKEN(sym_tag_name);
+<<<<<<< HEAD
       if (lookahead == 'c') ADVANCE(68);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+      if (lookahead == 'e') ADVANCE(102);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
-    case 41:
+    case 46:
       ACCEPT_TOKEN(sym_tag_name);
+<<<<<<< HEAD
       if (lookahead == 'c') ADVANCE(52);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+      if (lookahead == 'e') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
-    case 42:
+    case 47:
       ACCEPT_TOKEN(sym_tag_name);
+<<<<<<< HEAD
       if (lookahead == 'c') ADVANCE(115);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+      if (lookahead == 'e') ADVANCE(26);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
-    case 43:
+    case 48:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'e') ADVANCE(29);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 49:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'e') ADVANCE(100);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 50:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'e') ADVANCE(73);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 51:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'c') ADVANCE(48);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+<<<<<<< HEAD
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
-    case 44:
+    case 52:
       ACCEPT_TOKEN(sym_tag_name);
+<<<<<<< HEAD
       if (lookahead == 'c') ADVANCE(113);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
@@ -1208,47 +1677,423 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+      if (lookahead == 'e') ADVANCE(91);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 53:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'e') ADVANCE(96);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 54:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'e') ADVANCE(75);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 55:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'g') ADVANCE(68);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 56:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'h') ADVANCE(89);
+      if (lookahead == 'y') ADVANCE(84);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 57:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'i') ADVANCE(113);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 58:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'i') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 59:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'i') ADVANCE(36);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 60:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'i') ADVANCE(92);
+      if (lookahead == 'u') ADVANCE(72);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 61:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'i') ADVANCE(80);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 62:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'k') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 63:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'l') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 64:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'l') ADVANCE(38);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'l') ADVANCE(64);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 66:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'm') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 67:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'm') ADVANCE(47);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 68:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'm') ADVANCE(54);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'n') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 70:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'n') ADVANCE(99);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 71:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'n') ADVANCE(28);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 72:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'n') ADVANCE(42);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 73:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'n') ADVANCE(101);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 74:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'n') ADVANCE(35);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 75:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'n') ADVANCE(104);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 76:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(93);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 77:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(111);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 78:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(112);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 79:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(95);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 80:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(69);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 81:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(87);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 82:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(86);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 83:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'p') ADVANCE(37);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 84:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'p') ADVANCE(48);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 85:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'p') ADVANCE(79);
+      if (lookahead == 't') ADVANCE(52);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 86:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'p') ADVANCE(53);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 87:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(109);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 89:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(77);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 90:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(78);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 91:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(74);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(51);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 93:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(90);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 94:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(71);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 95:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(104);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 96:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(103);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 97:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'r') ADVANCE(32);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 98:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 's') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 112:
       ACCEPT_TOKEN(sym_tag_name);
+<<<<<<< HEAD
       if (lookahead == 't') ADVANCE(65);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+      if (lookahead == 's') ADVANCE(106);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym_tag_name);
+<<<<<<< HEAD
       if (lookahead == 't') ADVANCE(66);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+      if (lookahead == 's') ADVANCE(98);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym_tag_name);
+<<<<<<< HEAD
       if (lookahead == 't') ADVANCE(95);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+      if (lookahead == 't') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym_tag_name);
+<<<<<<< HEAD
       if (lookahead == 't') ADVANCE(89);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+=======
+      if (lookahead == 't') ADVANCE(108);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 116:
       ACCEPT_TOKEN(sym_tag_name);
+<<<<<<< HEAD
       if (lookahead == 'u') ADVANCE(100);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
       END_STATE();
     case 117:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'u') ADVANCE(42);
+=======
+      if (lookahead == 't') ADVANCE(114);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 104:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 't') ADVANCE(98);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 105:
+>>>>>>> 5ee169e (Permit braces in more contexts)
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 't') ADVANCE(61);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+<<<<<<< HEAD
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
       END_STATE();
     case 118:
@@ -1319,11 +2164,112 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 132:
+=======
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 106:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 't') ADVANCE(88);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 107:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 't') ADVANCE(81);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 108:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'u') ADVANCE(94);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 109:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'u') ADVANCE(43);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 110:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'v') ADVANCE(50);
+      if (lookahead == 'x') ADVANCE(85);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 111:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'w') ADVANCE(28);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 112:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'w') ADVANCE(98);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 113:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'x') ADVANCE(51);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 114:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'y') ADVANCE(27);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+      END_STATE();
+    case 116:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 117:
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      END_STATE();
+    case 118:
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      if (lookahead == '*') ADVANCE(128);
+      END_STATE();
+    case 119:
+      ACCEPT_TOKEN(anon_sym_DOT);
+      END_STATE();
+    case 120:
+      ACCEPT_TOKEN(anon_sym_POUND);
+      END_STATE();
+    case 121:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      END_STATE();
+    case 122:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      END_STATE();
+    case 123:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      END_STATE();
+    case 124:
+>>>>>>> 5ee169e (Permit braces in more contexts)
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == '$' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
+<<<<<<< HEAD
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
       END_STATE();
     case 133:
@@ -1359,23 +2305,46 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '{' &&
           lookahead != '}') ADVANCE(136);
+=======
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 137:
       ACCEPT_TOKEN(sym__text);
+<<<<<<< HEAD
       if (lookahead == '*') ADVANCE(137);
+=======
+      if (lookahead == '*') ADVANCE(126);
+      if (lookahead == '/') ADVANCE(125);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '{' &&
+          lookahead != '}') ADVANCE(125);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(sym__text);
+      if (lookahead == '*') ADVANCE(126);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '/' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(16);
+          lookahead != '}') ADVANCE(15);
       END_STATE();
+<<<<<<< HEAD
     case 138:
       ACCEPT_TOKEN(sym__text);
       if (lookahead == '/') ADVANCE(138);
+=======
+    case 127:
+      ACCEPT_TOKEN(sym__text);
+      if (lookahead == '/') ADVANCE(127);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '*' &&
           lookahead != '{' &&
+<<<<<<< HEAD
           lookahead != '}') ADVANCE(136);
       END_STATE();
     case 139:
@@ -1384,10 +2353,24 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 140:
       ACCEPT_TOKEN(sym__end);
+=======
+          lookahead != '}') ADVANCE(125);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(sym__begin);
+      if (lookahead == '*') ADVANCE(128);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 141:
       ACCEPT_TOKEN(sym__end);
+<<<<<<< HEAD
       if (lookahead == '*') ADVANCE(139);
+=======
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(sym__end);
+      if (lookahead == '*') ADVANCE(128);
+>>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     default:
       return false;
@@ -1395,57 +2378,74 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 }
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
-  [0] = {.lex_state = 0},
+  [0] = {.lex_state = 0, .external_lex_state = 1},
   [1] = {.lex_state = 2},
   [2] = {.lex_state = 4},
   [3] = {.lex_state = 4},
   [4] = {.lex_state = 7},
-  [5] = {.lex_state = 6},
-  [6] = {.lex_state = 9},
+  [5] = {.lex_state = 9},
+  [6] = {.lex_state = 11},
   [7] = {.lex_state = 9},
-  [8] = {.lex_state = 11},
-  [9] = {.lex_state = 11},
-  [10] = {.lex_state = 9},
+  [8] = {.lex_state = 6},
+  [9] = {.lex_state = 9},
+  [10] = {.lex_state = 11},
   [11] = {.lex_state = 11},
   [12] = {.lex_state = 9},
-  [13] = {.lex_state = 9},
-  [14] = {.lex_state = 9},
+  [13] = {.lex_state = 11},
+  [14] = {.lex_state = 11},
   [15] = {.lex_state = 11},
-  [16] = {.lex_state = 11},
-  [17] = {.lex_state = 0},
-  [18] = {.lex_state = 4},
-  [19] = {.lex_state = 4},
-  [20] = {.lex_state = 4},
-  [21] = {.lex_state = 11},
+  [16] = {.lex_state = 0},
+  [17] = {.lex_state = 9},
+  [18] = {.lex_state = 9},
+  [19] = {.lex_state = 9},
+  [20] = {.lex_state = 9},
+  [21] = {.lex_state = 4},
   [22] = {.lex_state = 4},
-  [23] = {.lex_state = 11},
-  [24] = {.lex_state = 11},
+  [23] = {.lex_state = 9},
+  [24] = {.lex_state = 13},
   [25] = {.lex_state = 13},
-  [26] = {.lex_state = 13},
-  [27] = {.lex_state = 13},
-  [28] = {.lex_state = 4},
-  [29] = {.lex_state = 4},
+  [26] = {.lex_state = 4},
+  [27] = {.lex_state = 4},
+  [28] = {.lex_state = 13},
+  [29] = {.lex_state = 9},
   [30] = {.lex_state = 4},
   [31] = {.lex_state = 4},
-  [32] = {.lex_state = 13},
-  [33] = {.lex_state = 13},
-  [34] = {.lex_state = 0},
+  [32] = {.lex_state = 4},
+  [33] = {.lex_state = 4},
+  [34] = {.lex_state = 13},
   [35] = {.lex_state = 13},
-  [36] = {.lex_state = 15},
-  [37] = {.lex_state = 0},
+  [36] = {.lex_state = 13},
+  [37] = {.lex_state = 14},
   [38] = {.lex_state = 0},
-  [39] = {.lex_state = 0},
-  [40] = {.lex_state = 0},
+  [39] = {.lex_state = 13},
+  [40] = {.lex_state = 14},
   [41] = {.lex_state = 0},
-  [42] = {.lex_state = 2},
+  [42] = {.lex_state = 0},
   [43] = {.lex_state = 0},
-  [44] = {.lex_state = 0},
-  [45] = {.lex_state = 2},
-  [46] = {.lex_state = 15},
-  [47] = {.lex_state = 0},
-  [48] = {.lex_state = 0},
+  [44] = {.lex_state = 0, .external_lex_state = 1},
+  [45] = {.lex_state = 0},
+  [46] = {.lex_state = 0},
+  [47] = {.lex_state = 0, .external_lex_state = 1},
+  [48] = {.lex_state = 2},
   [49] = {.lex_state = 0},
-  [50] = {.lex_state = 2},
+  [50] = {.lex_state = 0},
+  [51] = {.lex_state = 0},
+  [52] = {.lex_state = 0},
+  [53] = {.lex_state = 0},
+};
+
+enum {
+  ts_external_token_type = 0,
+};
+
+static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
+  [ts_external_token_type] = sym_type,
+};
+
+static const bool ts_external_scanner_states[2][EXTERNAL_TOKEN_COUNT] = {
+  [1] = {
+    [ts_external_token_type] = true,
+  },
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1467,9 +2467,10 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym__text] = ACTIONS(1),
     [sym__begin] = ACTIONS(1),
     [sym__end] = ACTIONS(1),
+    [sym_type] = ACTIONS(1),
   },
   [1] = {
-    [sym_document] = STATE(40),
+    [sym_document] = STATE(51),
     [sym__begin] = ACTIONS(3),
   },
 };
@@ -1486,13 +2487,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text,
     ACTIONS(15), 1,
       sym__end,
-    STATE(31), 1,
+    STATE(30), 1,
       sym_description,
     ACTIONS(7), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-    STATE(6), 5,
+    STATE(10), 5,
       sym__expression,
       sym_qualified_expression,
       sym_path_expression,
@@ -1507,13 +2508,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text,
     ACTIONS(19), 1,
       sym__end,
-    STATE(29), 1,
+    STATE(33), 1,
       sym_description,
     ACTIONS(17), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-    STATE(7), 5,
+    STATE(6), 5,
       sym__expression,
       sym_qualified_expression,
       sym_path_expression,
@@ -1534,165 +2535,155 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tag_name,
       sym__text,
       sym__end,
-  [78] = 3,
-    ACTIONS(23), 1,
-      anon_sym_COLON,
-    ACTIONS(29), 4,
+  [78] = 5,
+    ACTIONS(29), 1,
+      anon_sym_LBRACE,
+    ACTIONS(33), 1,
+      sym__text,
+    ACTIONS(35), 1,
+      sym__end,
+    ACTIONS(31), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-      sym__text,
-    ACTIONS(31), 4,
-      anon_sym_DOT,
-      anon_sym_POUND,
-      anon_sym_TILDE,
-      sym__end,
-  [94] = 5,
-    ACTIONS(13), 1,
-      sym__text,
-    ACTIONS(37), 1,
-      sym__end,
-    STATE(30), 1,
-      sym_description,
-    ACTIONS(33), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-    ACTIONS(35), 3,
-      anon_sym_DOT,
-      anon_sym_POUND,
-      anon_sym_TILDE,
-  [114] = 5,
+    STATE(9), 3,
+      sym_inline_tag,
+      sym__inline_tag_false_positive,
+      aux_sym_description_repeat1,
+  [98] = 5,
     ACTIONS(13), 1,
       sym__text,
     ACTIONS(41), 1,
       sym__end,
-    STATE(28), 1,
+    STATE(32), 1,
       sym_description,
-    ACTIONS(35), 3,
+    ACTIONS(37), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+    ACTIONS(39), 3,
       anon_sym_DOT,
       anon_sym_POUND,
       anon_sym_TILDE,
-    ACTIONS(39), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-  [134] = 5,
+  [118] = 5,
     ACTIONS(43), 1,
       anon_sym_LBRACE,
-    ACTIONS(47), 1,
-      sym__text,
-    ACTIONS(49), 1,
-      sym__end,
-    STATE(15), 2,
-      sym_inline_tag,
-      aux_sym_description_repeat1,
-    ACTIONS(45), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-  [153] = 7,
-    ACTIONS(13), 1,
+    ACTIONS(48), 1,
       sym__text,
     ACTIONS(51), 1,
-      sym_tag_name_with_argument,
-    ACTIONS(53), 1,
-      sym_tag_name_with_type,
-    ACTIONS(55), 1,
-      sym_tag_name,
-    ACTIONS(57), 1,
       sym__end,
-    STATE(18), 1,
-      sym_description,
-    STATE(22), 2,
-      sym_tag,
-      aux_sym_document_repeat1,
-  [176] = 2,
-    ACTIONS(29), 4,
+    ACTIONS(46), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+    STATE(7), 3,
+      sym_inline_tag,
+      sym__inline_tag_false_positive,
+      aux_sym_description_repeat1,
+  [138] = 3,
+    ACTIONS(23), 1,
+      anon_sym_COLON,
+    ACTIONS(53), 4,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
       sym__text,
-    ACTIONS(31), 4,
+    ACTIONS(55), 4,
       anon_sym_DOT,
       anon_sym_POUND,
       anon_sym_TILDE,
       sym__end,
-  [189] = 5,
-    ACTIONS(43), 1,
+  [154] = 5,
+    ACTIONS(29), 1,
       anon_sym_LBRACE,
+    ACTIONS(59), 1,
+      sym__text,
     ACTIONS(61), 1,
-      sym__text,
-    ACTIONS(63), 1,
       sym__end,
-    STATE(8), 2,
+    ACTIONS(57), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+    STATE(7), 3,
       sym_inline_tag,
+      sym__inline_tag_false_positive,
       aux_sym_description_repeat1,
-    ACTIONS(59), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-  [208] = 2,
-    ACTIONS(65), 4,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-      sym__text,
-    ACTIONS(67), 4,
-      anon_sym_DOT,
-      anon_sym_POUND,
-      anon_sym_TILDE,
-      sym__end,
-  [221] = 2,
-    ACTIONS(69), 4,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-      sym__text,
-    ACTIONS(71), 4,
-      anon_sym_DOT,
-      anon_sym_POUND,
-      anon_sym_TILDE,
-      sym__end,
-  [234] = 2,
-    ACTIONS(73), 4,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-      sym__text,
-    ACTIONS(75), 4,
-      anon_sym_DOT,
-      anon_sym_POUND,
-      anon_sym_TILDE,
-      sym__end,
-  [247] = 5,
-    ACTIONS(77), 1,
-      anon_sym_LBRACE,
-    ACTIONS(82), 1,
-      sym__text,
-    ACTIONS(85), 1,
-      sym__end,
-    STATE(15), 2,
-      sym_inline_tag,
-      aux_sym_description_repeat1,
-    ACTIONS(80), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-  [266] = 5,
+  [174] = 5,
     ACTIONS(13), 1,
       sym__text,
-    ACTIONS(15), 1,
+    ACTIONS(65), 1,
       sym__end,
-    ACTIONS(87), 1,
-      anon_sym_LBRACE,
     STATE(31), 1,
       sym_description,
-    ACTIONS(7), 3,
+    ACTIONS(39), 3,
+      anon_sym_DOT,
+      anon_sym_POUND,
+      anon_sym_TILDE,
+    ACTIONS(63), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-  [284] = 3,
+  [194] = 2,
+    ACTIONS(67), 4,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+      sym__text,
+    ACTIONS(69), 4,
+      anon_sym_DOT,
+      anon_sym_POUND,
+      anon_sym_TILDE,
+      sym__end,
+  [207] = 7,
+    ACTIONS(13), 1,
+      sym__text,
+    ACTIONS(71), 1,
+      sym_tag_name_with_argument,
+    ACTIONS(73), 1,
+      sym_tag_name_with_type,
+    ACTIONS(75), 1,
+      sym_tag_name,
+    ACTIONS(77), 1,
+      sym__end,
+    STATE(27), 1,
+      sym_description,
+    STATE(26), 2,
+      sym_tag,
+      aux_sym_document_repeat1,
+  [230] = 2,
+    ACTIONS(79), 4,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+      sym__text,
+    ACTIONS(81), 4,
+      anon_sym_DOT,
+      anon_sym_POUND,
+      anon_sym_TILDE,
+      sym__end,
+  [243] = 2,
+    ACTIONS(83), 4,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+      sym__text,
+    ACTIONS(85), 4,
+      anon_sym_DOT,
+      anon_sym_POUND,
+      anon_sym_TILDE,
+      sym__end,
+  [256] = 2,
+    ACTIONS(53), 4,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+      sym__text,
+    ACTIONS(55), 4,
+      anon_sym_DOT,
+      anon_sym_POUND,
+      anon_sym_TILDE,
+      sym__end,
+  [269] = 3,
     ACTIONS(9), 1,
       anon_sym_LBRACK,
     ACTIONS(11), 1,
@@ -1703,208 +2694,253 @@ static const uint16_t ts_small_parse_table[] = {
       sym_path_expression,
       sym_member_expression,
       sym_optional_identifier,
-  [298] = 5,
-    ACTIONS(51), 1,
-      sym_tag_name_with_argument,
-    ACTIONS(53), 1,
-      sym_tag_name_with_type,
-    ACTIONS(55), 1,
-      sym_tag_name,
-    ACTIONS(89), 1,
-      sym__end,
-    STATE(19), 2,
-      sym_tag,
-      aux_sym_document_repeat1,
-  [315] = 5,
-    ACTIONS(51), 1,
-      sym_tag_name_with_argument,
-    ACTIONS(53), 1,
-      sym_tag_name_with_type,
-    ACTIONS(55), 1,
-      sym_tag_name,
-    ACTIONS(91), 1,
-      sym__end,
-    STATE(20), 2,
-      sym_tag,
-      aux_sym_document_repeat1,
-  [332] = 5,
-    ACTIONS(93), 1,
-      sym_tag_name_with_argument,
-    ACTIONS(96), 1,
-      sym_tag_name_with_type,
-    ACTIONS(99), 1,
-      sym_tag_name,
-    ACTIONS(102), 1,
-      sym__end,
-    STATE(20), 2,
-      sym_tag,
-      aux_sym_document_repeat1,
-  [349] = 2,
-    ACTIONS(104), 2,
-      anon_sym_LBRACE,
-      sym__end,
-    ACTIONS(106), 4,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-      sym__text,
-  [360] = 5,
-    ACTIONS(51), 1,
-      sym_tag_name_with_argument,
-    ACTIONS(53), 1,
-      sym_tag_name_with_type,
-    ACTIONS(55), 1,
-      sym_tag_name,
-    ACTIONS(89), 1,
-      sym__end,
-    STATE(20), 2,
-      sym_tag,
-      aux_sym_document_repeat1,
-  [377] = 4,
-    ACTIONS(13), 1,
-      sym__text,
-    ACTIONS(19), 1,
-      sym__end,
-    STATE(29), 1,
-      sym_description,
-    ACTIONS(17), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-  [392] = 4,
+  [283] = 5,
     ACTIONS(13), 1,
       sym__text,
     ACTIONS(15), 1,
       sym__end,
-    STATE(31), 1,
+    ACTIONS(87), 1,
+      anon_sym_LBRACE,
+    STATE(30), 1,
       sym_description,
     ACTIONS(7), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-  [407] = 4,
-    ACTIONS(63), 1,
+  [301] = 3,
+    ACTIONS(91), 1,
       anon_sym_RBRACE,
-    ACTIONS(108), 1,
+    ACTIONS(89), 2,
       anon_sym_LBRACE,
+      sym__end,
+    ACTIONS(93), 4,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+      sym__text,
+  [315] = 2,
+    ACTIONS(95), 2,
+      anon_sym_LBRACE,
+      sym__end,
+    ACTIONS(97), 4,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+      sym__text,
+  [326] = 4,
+    ACTIONS(13), 1,
+      sym__text,
+    ACTIONS(19), 1,
+      sym__end,
+    STATE(33), 1,
+      sym_description,
+    ACTIONS(17), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [341] = 5,
+    ACTIONS(71), 1,
+      sym_tag_name_with_argument,
+    ACTIONS(73), 1,
+      sym_tag_name_with_type,
+    ACTIONS(75), 1,
+      sym_tag_name,
+    ACTIONS(99), 1,
+      sym__end,
+    STATE(22), 2,
+      sym_tag,
+      aux_sym_document_repeat1,
+  [358] = 5,
+    ACTIONS(101), 1,
+      sym_tag_name_with_argument,
+    ACTIONS(104), 1,
+      sym_tag_name_with_type,
+    ACTIONS(107), 1,
+      sym_tag_name,
     ACTIONS(110), 1,
-      sym__text,
-    STATE(26), 2,
-      sym_inline_tag,
-      aux_sym_description_repeat1,
-  [421] = 4,
-    ACTIONS(49), 1,
-      anon_sym_RBRACE,
-    ACTIONS(108), 1,
-      anon_sym_LBRACE,
-    ACTIONS(112), 1,
-      sym__text,
-    STATE(27), 2,
-      sym_inline_tag,
-      aux_sym_description_repeat1,
-  [435] = 4,
-    ACTIONS(85), 1,
-      anon_sym_RBRACE,
-    ACTIONS(114), 1,
-      anon_sym_LBRACE,
-    ACTIONS(117), 1,
-      sym__text,
-    STATE(27), 2,
-      sym_inline_tag,
-      aux_sym_description_repeat1,
-  [449] = 2,
-    ACTIONS(122), 1,
       sym__end,
-    ACTIONS(120), 3,
+    STATE(22), 2,
+      sym_tag,
+      aux_sym_document_repeat1,
+  [375] = 2,
+    ACTIONS(112), 2,
+      anon_sym_LBRACE,
+      sym__end,
+    ACTIONS(114), 4,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-  [458] = 2,
-    ACTIONS(41), 1,
-      sym__end,
-    ACTIONS(39), 3,
+      sym__text,
+  [386] = 4,
+    ACTIONS(35), 1,
+      anon_sym_RBRACE,
+    ACTIONS(116), 1,
+      anon_sym_LBRACE,
+    ACTIONS(118), 1,
+      sym__text,
+    STATE(28), 3,
+      sym_inline_tag,
+      sym__inline_tag_false_positive,
+      aux_sym_description_repeat1,
+  [401] = 4,
+    ACTIONS(51), 1,
+      anon_sym_RBRACE,
+    ACTIONS(120), 1,
+      anon_sym_LBRACE,
+    ACTIONS(123), 1,
+      sym__text,
+    STATE(25), 3,
+      sym_inline_tag,
+      sym__inline_tag_false_positive,
+      aux_sym_description_repeat1,
+  [416] = 5,
+    ACTIONS(71), 1,
       sym_tag_name_with_argument,
+    ACTIONS(73), 1,
       sym_tag_name_with_type,
+    ACTIONS(75), 1,
       sym_tag_name,
-  [467] = 2,
     ACTIONS(126), 1,
       sym__end,
-    ACTIONS(124), 3,
+    STATE(22), 2,
+      sym_tag,
+      aux_sym_document_repeat1,
+  [433] = 5,
+    ACTIONS(71), 1,
       sym_tag_name_with_argument,
+    ACTIONS(73), 1,
       sym_tag_name_with_type,
+    ACTIONS(75), 1,
       sym_tag_name,
-  [476] = 2,
-    ACTIONS(37), 1,
+    ACTIONS(126), 1,
       sym__end,
-    ACTIONS(33), 3,
+    STATE(21), 2,
+      sym_tag,
+      aux_sym_document_repeat1,
+  [450] = 4,
+    ACTIONS(61), 1,
+      anon_sym_RBRACE,
+    ACTIONS(116), 1,
+      anon_sym_LBRACE,
+    ACTIONS(128), 1,
+      sym__text,
+    STATE(25), 3,
+      sym_inline_tag,
+      sym__inline_tag_false_positive,
+      aux_sym_description_repeat1,
+  [465] = 4,
+    ACTIONS(13), 1,
+      sym__text,
+    ACTIONS(15), 1,
+      sym__end,
+    STATE(30), 1,
+      sym_description,
+    ACTIONS(7), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-  [485] = 1,
-    ACTIONS(104), 3,
+  [480] = 2,
+    ACTIONS(65), 1,
+      sym__end,
+    ACTIONS(63), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [489] = 2,
+    ACTIONS(132), 1,
+      sym__end,
+    ACTIONS(130), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [498] = 2,
+    ACTIONS(136), 1,
+      sym__end,
+    ACTIONS(134), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [507] = 2,
+    ACTIONS(41), 1,
+      sym__end,
+    ACTIONS(37), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [516] = 1,
+    ACTIONS(112), 3,
       anon_sym_LBRACE,
       anon_sym_RBRACE,
       sym__text,
-  [491] = 2,
-    ACTIONS(128), 1,
-      sym__text,
-    STATE(48), 1,
-      sym_description,
-  [498] = 2,
-    ACTIONS(130), 1,
-      sym_identifier,
-    STATE(10), 1,
-      sym_qualified_expression,
-  [505] = 2,
-    ACTIONS(128), 1,
-      sym__text,
-    STATE(39), 1,
-      sym_description,
-  [512] = 1,
-    ACTIONS(132), 1,
-      sym_type,
-  [516] = 1,
-    ACTIONS(134), 1,
-      ts_builtin_sym_end,
-  [520] = 1,
-    ACTIONS(136), 1,
+  [522] = 1,
+    ACTIONS(89), 3,
+      anon_sym_LBRACE,
       anon_sym_RBRACE,
-  [524] = 1,
+      sym__text,
+  [528] = 2,
     ACTIONS(138), 1,
-      anon_sym_RBRACE,
-  [528] = 1,
+      sym__text,
+    STATE(52), 1,
+      sym_description,
+  [535] = 2,
     ACTIONS(140), 1,
-      ts_builtin_sym_end,
-  [532] = 1,
+      aux_sym__inline_tag_false_positive_token1,
     ACTIONS(142), 1,
-      sym_identifier,
-  [536] = 1,
+      sym_tag_name,
+  [542] = 2,
     ACTIONS(144), 1,
-      anon_sym_RBRACK,
-  [540] = 1,
-    ACTIONS(146), 1,
-      anon_sym_RBRACE,
-  [544] = 1,
-    ACTIONS(148), 1,
-      ts_builtin_sym_end,
-  [548] = 1,
-    ACTIONS(150), 1,
-      sym_tag_name,
-  [552] = 1,
-    ACTIONS(152), 1,
-      sym_type,
-  [556] = 1,
-    ACTIONS(154), 1,
       sym_identifier,
-  [560] = 1,
-    ACTIONS(156), 1,
-      anon_sym_RBRACE,
-  [564] = 1,
-    ACTIONS(158), 1,
-      ts_builtin_sym_end,
-  [568] = 1,
-    ACTIONS(160), 1,
+    STATE(15), 1,
+      sym_qualified_expression,
+  [549] = 2,
+    ACTIONS(138), 1,
+      sym__text,
+    STATE(41), 1,
+      sym_description,
+  [556] = 2,
+    ACTIONS(146), 1,
+      aux_sym__inline_tag_false_positive_token1,
+    ACTIONS(148), 1,
       sym_tag_name,
+  [563] = 1,
+    ACTIONS(150), 1,
+      anon_sym_RBRACE,
+  [567] = 1,
+    ACTIONS(152), 1,
+      ts_builtin_sym_end,
+  [571] = 1,
+    ACTIONS(154), 1,
+      ts_builtin_sym_end,
+  [575] = 1,
+    ACTIONS(156), 1,
+      sym_type,
+  [579] = 1,
+    ACTIONS(158), 1,
+      anon_sym_RBRACE,
+  [583] = 1,
+    ACTIONS(160), 1,
+      sym_identifier,
+  [587] = 1,
+    ACTIONS(162), 1,
+      sym_type,
+  [591] = 1,
+    ACTIONS(164), 1,
+      anon_sym_RBRACK,
+  [595] = 1,
+    ACTIONS(166), 1,
+      ts_builtin_sym_end,
+  [599] = 1,
+    ACTIONS(168), 1,
+      sym_identifier,
+  [603] = 1,
+    ACTIONS(170), 1,
+      ts_builtin_sym_end,
+  [607] = 1,
+    ACTIONS(172), 1,
+      anon_sym_RBRACE,
+  [611] = 1,
+    ACTIONS(174), 1,
+      anon_sym_RBRACE,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
@@ -1912,137 +2948,153 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(3)] = 31,
   [SMALL_STATE(4)] = 59,
   [SMALL_STATE(5)] = 78,
-  [SMALL_STATE(6)] = 94,
-  [SMALL_STATE(7)] = 114,
-  [SMALL_STATE(8)] = 134,
-  [SMALL_STATE(9)] = 153,
-  [SMALL_STATE(10)] = 176,
-  [SMALL_STATE(11)] = 189,
-  [SMALL_STATE(12)] = 208,
-  [SMALL_STATE(13)] = 221,
-  [SMALL_STATE(14)] = 234,
-  [SMALL_STATE(15)] = 247,
-  [SMALL_STATE(16)] = 266,
-  [SMALL_STATE(17)] = 284,
-  [SMALL_STATE(18)] = 298,
+  [SMALL_STATE(6)] = 98,
+  [SMALL_STATE(7)] = 118,
+  [SMALL_STATE(8)] = 138,
+  [SMALL_STATE(9)] = 154,
+  [SMALL_STATE(10)] = 174,
+  [SMALL_STATE(11)] = 194,
+  [SMALL_STATE(12)] = 207,
+  [SMALL_STATE(13)] = 230,
+  [SMALL_STATE(14)] = 243,
+  [SMALL_STATE(15)] = 256,
+  [SMALL_STATE(16)] = 269,
+  [SMALL_STATE(17)] = 283,
+  [SMALL_STATE(18)] = 301,
   [SMALL_STATE(19)] = 315,
-  [SMALL_STATE(20)] = 332,
-  [SMALL_STATE(21)] = 349,
-  [SMALL_STATE(22)] = 360,
-  [SMALL_STATE(23)] = 377,
-  [SMALL_STATE(24)] = 392,
-  [SMALL_STATE(25)] = 407,
-  [SMALL_STATE(26)] = 421,
-  [SMALL_STATE(27)] = 435,
-  [SMALL_STATE(28)] = 449,
-  [SMALL_STATE(29)] = 458,
-  [SMALL_STATE(30)] = 467,
-  [SMALL_STATE(31)] = 476,
-  [SMALL_STATE(32)] = 485,
-  [SMALL_STATE(33)] = 491,
-  [SMALL_STATE(34)] = 498,
-  [SMALL_STATE(35)] = 505,
-  [SMALL_STATE(36)] = 512,
-  [SMALL_STATE(37)] = 516,
-  [SMALL_STATE(38)] = 520,
-  [SMALL_STATE(39)] = 524,
-  [SMALL_STATE(40)] = 528,
-  [SMALL_STATE(41)] = 532,
-  [SMALL_STATE(42)] = 536,
-  [SMALL_STATE(43)] = 540,
-  [SMALL_STATE(44)] = 544,
-  [SMALL_STATE(45)] = 548,
-  [SMALL_STATE(46)] = 552,
-  [SMALL_STATE(47)] = 556,
-  [SMALL_STATE(48)] = 560,
-  [SMALL_STATE(49)] = 564,
-  [SMALL_STATE(50)] = 568,
+  [SMALL_STATE(20)] = 326,
+  [SMALL_STATE(21)] = 341,
+  [SMALL_STATE(22)] = 358,
+  [SMALL_STATE(23)] = 375,
+  [SMALL_STATE(24)] = 386,
+  [SMALL_STATE(25)] = 401,
+  [SMALL_STATE(26)] = 416,
+  [SMALL_STATE(27)] = 433,
+  [SMALL_STATE(28)] = 450,
+  [SMALL_STATE(29)] = 465,
+  [SMALL_STATE(30)] = 480,
+  [SMALL_STATE(31)] = 489,
+  [SMALL_STATE(32)] = 498,
+  [SMALL_STATE(33)] = 507,
+  [SMALL_STATE(34)] = 516,
+  [SMALL_STATE(35)] = 522,
+  [SMALL_STATE(36)] = 528,
+  [SMALL_STATE(37)] = 535,
+  [SMALL_STATE(38)] = 542,
+  [SMALL_STATE(39)] = 549,
+  [SMALL_STATE(40)] = 556,
+  [SMALL_STATE(41)] = 563,
+  [SMALL_STATE(42)] = 567,
+  [SMALL_STATE(43)] = 571,
+  [SMALL_STATE(44)] = 575,
+  [SMALL_STATE(45)] = 579,
+  [SMALL_STATE(46)] = 583,
+  [SMALL_STATE(47)] = 587,
+  [SMALL_STATE(48)] = 591,
+  [SMALL_STATE(49)] = 595,
+  [SMALL_STATE(50)] = 599,
+  [SMALL_STATE(51)] = 603,
+  [SMALL_STATE(52)] = 607,
+  [SMALL_STATE(53)] = 611,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
   [7] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 1),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
   [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
   [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 1),
   [17] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 4),
   [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 4),
   [21] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression, 1),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
   [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
-  [29] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_member_expression, 3),
-  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_member_expression, 3),
-  [33] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 2),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
-  [37] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
-  [39] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 5),
+  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [31] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_description, 1),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_description, 1),
+  [37] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 5),
+  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
   [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 5),
-  [43] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [45] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_description, 2),
-  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [49] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_description, 2),
-  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
-  [53] = {.entry = {.count = 1, .reusable = false}}, SHIFT(16),
-  [55] = {.entry = {.count = 1, .reusable = false}}, SHIFT(24),
-  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [59] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_description, 1),
-  [61] = {.entry = {.count = 1, .reusable = false}}, SHIFT(8),
-  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_description, 1),
-  [65] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_path_expression, 3),
-  [67] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path_expression, 3),
-  [69] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_qualified_expression, 3),
-  [71] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_qualified_expression, 3),
-  [73] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optional_identifier, 3),
-  [75] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optional_identifier, 3),
-  [77] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(45),
-  [80] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2),
-  [82] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(15),
-  [85] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2),
-  [87] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [89] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [91] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [93] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(2),
-  [96] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(16),
-  [99] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(24),
-  [102] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
-  [104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_tag, 4),
-  [106] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_tag, 4),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
-  [112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [114] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(50),
-  [117] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(27),
-  [120] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 6),
-  [122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 6),
-  [124] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
-  [126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
+  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(40),
+  [46] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2),
+  [48] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(7),
+  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2),
+  [53] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_member_expression, 3),
+  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_member_expression, 3),
+  [57] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_description, 2),
+  [59] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
+  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_description, 2),
+  [63] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 2),
+  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
+  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optional_identifier, 3),
+  [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optional_identifier, 3),
+  [71] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
+  [73] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [75] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [79] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_qualified_expression, 3),
+  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_qualified_expression, 3),
+  [83] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_path_expression, 3),
+  [85] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path_expression, 3),
+  [87] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__inline_tag_false_positive, 2),
+  [91] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [93] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__inline_tag_false_positive, 2),
+  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__inline_tag_false_positive, 3),
+  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__inline_tag_false_positive, 3),
+  [99] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [101] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(2),
+  [104] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(17),
+  [107] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(29),
+  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
+  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_tag, 4),
+  [114] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_tag, 4),
+  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(37),
+  [123] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(25),
+  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
   [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [130] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [134] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 4),
-  [136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [140] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [148] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3),
-  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [158] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2),
-  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [130] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
+  [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
+  [134] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 6),
+  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 6),
+  [138] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [142] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
+  [144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [148] = {.entry = {.count = 1, .reusable = false}}, SHIFT(39),
+  [150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3),
+  [154] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 4),
+  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2),
+  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [170] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
 };
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+void *tree_sitter_jsdoc_external_scanner_create(void);
+void tree_sitter_jsdoc_external_scanner_destroy(void *);
+bool tree_sitter_jsdoc_external_scanner_scan(void *, TSLexer *, const bool *);
+unsigned tree_sitter_jsdoc_external_scanner_serialize(void *, char *);
+void tree_sitter_jsdoc_external_scanner_deserialize(void *, const char *, unsigned);
+
 #ifdef _WIN32
 #define extern __declspec(dllexport)
 #endif
@@ -2070,6 +3122,15 @@ extern const TSLanguage *tree_sitter_jsdoc(void) {
     .alias_sequences = &ts_alias_sequences[0][0],
     .lex_modes = ts_lex_modes,
     .lex_fn = ts_lex,
+    .external_scanner = {
+      &ts_external_scanner_states[0][0],
+      ts_external_scanner_symbol_map,
+      tree_sitter_jsdoc_external_scanner_create,
+      tree_sitter_jsdoc_external_scanner_destroy,
+      tree_sitter_jsdoc_external_scanner_scan,
+      tree_sitter_jsdoc_external_scanner_serialize,
+      tree_sitter_jsdoc_external_scanner_deserialize,
+    },
     .primary_state_ids = ts_primary_state_ids,
   };
   return &language;

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,11 +6,11 @@
 #endif
 
 #define LANGUAGE_VERSION 14
-#define STATE_COUNT 55
+#define STATE_COUNT 51
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 32
+#define SYMBOL_COUNT 30
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 20
+#define TOKEN_COUNT 19
 #define EXTERNAL_TOKEN_COUNT 1
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
@@ -19,43 +19,40 @@
 enum ts_symbol_identifiers {
   anon_sym_LBRACE = 1,
   anon_sym_RBRACE = 2,
-  aux_sym__inline_tag_false_positive_token1 = 3,
-  aux_sym__inline_tag_false_positive_token2 = 4,
-  sym_tag_name_with_argument = 5,
-  sym_tag_name_with_type = 6,
-  sym_tag_name = 7,
-  anon_sym_COLON = 8,
-  anon_sym_SLASH = 9,
-  anon_sym_DOT = 10,
-  anon_sym_POUND = 11,
-  anon_sym_TILDE = 12,
-  anon_sym_LBRACK = 13,
-  anon_sym_RBRACK = 14,
-  sym_identifier = 15,
-  sym__text = 16,
-  sym__begin = 17,
-  sym__end = 18,
-  sym_type = 19,
-  sym_document = 20,
-  sym_description = 21,
-  sym_tag = 22,
-  sym_inline_tag = 23,
-  sym__inline_tag_false_positive = 24,
-  sym__expression = 25,
-  sym_qualified_expression = 26,
-  sym_path_expression = 27,
-  sym_member_expression = 28,
-  sym_optional_identifier = 29,
-  aux_sym_document_repeat1 = 30,
-  aux_sym_description_repeat1 = 31,
+  sym__inline_tag_false_positive = 3,
+  sym_tag_name_with_argument = 4,
+  sym_tag_name_with_type = 5,
+  sym_tag_name = 6,
+  anon_sym_COLON = 7,
+  anon_sym_SLASH = 8,
+  anon_sym_DOT = 9,
+  anon_sym_POUND = 10,
+  anon_sym_TILDE = 11,
+  anon_sym_LBRACK = 12,
+  anon_sym_RBRACK = 13,
+  sym_identifier = 14,
+  sym__text = 15,
+  sym__begin = 16,
+  sym__end = 17,
+  sym_type = 18,
+  sym_document = 19,
+  sym_description = 20,
+  sym_tag = 21,
+  sym_inline_tag = 22,
+  sym__expression = 23,
+  sym_qualified_expression = 24,
+  sym_path_expression = 25,
+  sym_member_expression = 26,
+  sym_optional_identifier = 27,
+  aux_sym_document_repeat1 = 28,
+  aux_sym_description_repeat1 = 29,
 };
 
 static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [anon_sym_LBRACE] = "{",
   [anon_sym_RBRACE] = "}",
-  [aux_sym__inline_tag_false_positive_token1] = "_inline_tag_false_positive_token1",
-  [aux_sym__inline_tag_false_positive_token2] = "_inline_tag_false_positive_token2",
+  [sym__inline_tag_false_positive] = "_inline_tag_false_positive",
   [sym_tag_name_with_argument] = "tag_name",
   [sym_tag_name_with_type] = "tag_name",
   [sym_tag_name] = "tag_name",
@@ -75,7 +72,6 @@ static const char * const ts_symbol_names[] = {
   [sym_description] = "description",
   [sym_tag] = "tag",
   [sym_inline_tag] = "inline_tag",
-  [sym__inline_tag_false_positive] = "_inline_tag_false_positive",
   [sym__expression] = "_expression",
   [sym_qualified_expression] = "qualified_expression",
   [sym_path_expression] = "path_expression",
@@ -89,8 +85,7 @@ static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [anon_sym_LBRACE] = anon_sym_LBRACE,
   [anon_sym_RBRACE] = anon_sym_RBRACE,
-  [aux_sym__inline_tag_false_positive_token1] = aux_sym__inline_tag_false_positive_token1,
-  [aux_sym__inline_tag_false_positive_token2] = aux_sym__inline_tag_false_positive_token2,
+  [sym__inline_tag_false_positive] = sym__inline_tag_false_positive,
   [sym_tag_name_with_argument] = sym_tag_name,
   [sym_tag_name_with_type] = sym_tag_name,
   [sym_tag_name] = sym_tag_name,
@@ -110,7 +105,6 @@ static const TSSymbol ts_symbol_map[] = {
   [sym_description] = sym_description,
   [sym_tag] = sym_tag,
   [sym_inline_tag] = sym_inline_tag,
-  [sym__inline_tag_false_positive] = sym__inline_tag_false_positive,
   [sym__expression] = sym__expression,
   [sym_qualified_expression] = sym_qualified_expression,
   [sym_path_expression] = sym_path_expression,
@@ -133,13 +127,9 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym__inline_tag_false_positive_token1] = {
+  [sym__inline_tag_false_positive] = {
     .visible = false,
-    .named = false,
-  },
-  [aux_sym__inline_tag_false_positive_token2] = {
-    .visible = false,
-    .named = false,
+    .named = true,
   },
   [sym_tag_name_with_argument] = {
     .visible = true,
@@ -217,10 +207,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [sym__inline_tag_false_positive] = {
-    .visible = false,
-    .named = true,
-  },
   [sym__expression] = {
     .visible = false,
     .named = true,
@@ -282,39 +268,35 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [19] = 19,
   [20] = 20,
   [21] = 21,
-  [22] = 22,
-  [23] = 23,
-  [24] = 5,
-  [25] = 7,
+  [22] = 6,
+  [23] = 10,
+  [24] = 7,
+  [25] = 25,
   [26] = 26,
   [27] = 27,
-  [28] = 9,
+  [28] = 28,
   [29] = 29,
   [30] = 30,
   [31] = 31,
-  [32] = 32,
-  [33] = 18,
+  [32] = 16,
+  [33] = 33,
   [34] = 34,
-  [35] = 23,
-  [36] = 19,
+  [35] = 33,
+  [36] = 36,
   [37] = 37,
   [38] = 38,
   [39] = 39,
-  [40] = 37,
-  [41] = 38,
+  [40] = 40,
+  [41] = 41,
   [42] = 42,
   [43] = 43,
   [44] = 44,
   [45] = 45,
   [46] = 46,
   [47] = 47,
-  [48] = 48,
+  [48] = 39,
   [49] = 49,
-  [50] = 50,
-  [51] = 51,
-  [52] = 52,
-  [53] = 45,
-  [54] = 54,
+  [50] = 45,
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -322,20 +304,20 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(20);
-      if (lookahead == '\n') SKIP(18)
+      if (eof) ADVANCE(21);
+      if (lookahead == '\n') SKIP(19)
       if (lookahead == '#') ADVANCE(131);
       if (lookahead == '.') ADVANCE(130);
       if (lookahead == '/') ADVANCE(129);
       if (lookahead == ':') ADVANCE(127);
-      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(17);
       if (lookahead == '[') ADVANCE(133);
       if (lookahead == ']') ADVANCE(134);
-      if (lookahead == '{') ADVANCE(21);
-      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '{') ADVANCE(23);
+      if (lookahead == '}') ADVANCE(24);
       if (lookahead == '~') ADVANCE(132);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(19)
+          lookahead == ' ') SKIP(20)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
@@ -347,6 +329,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\n') SKIP(1)
       if (lookahead == '*') SKIP(1)
       if (lookahead == '/') ADVANCE(139);
+      if (lookahead == '@') ADVANCE(18);
       if (lookahead == ']') ADVANCE(134);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(1)
@@ -355,6 +338,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 2:
       if (lookahead == '\n') SKIP(1)
       if (lookahead == '/') ADVANCE(139);
+      if (lookahead == '@') ADVANCE(18);
       if (lookahead == ']') ADVANCE(134);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(2)
@@ -363,9 +347,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\n') SKIP(3)
       if (lookahead == '*') SKIP(3)
       if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(17);
       if (lookahead == '[') ADVANCE(133);
-      if (lookahead == '{') ADVANCE(21);
+      if (lookahead == '{') ADVANCE(22);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(3)
       if ((11 <= lookahead && lookahead <= '\r')) SKIP(4)
@@ -379,9 +363,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 4:
       if (lookahead == '\n') SKIP(3)
       if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(17);
       if (lookahead == '[') ADVANCE(133);
-      if (lookahead == '{') ADVANCE(21);
+      if (lookahead == '{') ADVANCE(22);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(4)
       if (lookahead == '$' ||
@@ -399,7 +383,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '.') ADVANCE(130);
       if (lookahead == '/') ADVANCE(140);
       if (lookahead == ':') ADVANCE(127);
-      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(17);
       if (lookahead == '~') ADVANCE(132);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
@@ -414,7 +398,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '.') ADVANCE(130);
       if (lookahead == '/') ADVANCE(140);
       if (lookahead == ':') ADVANCE(127);
-      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(17);
       if (lookahead == '~') ADVANCE(132);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(6)
@@ -429,7 +413,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '.') ADVANCE(130);
       if (lookahead == '/') ADVANCE(128);
       if (lookahead == ':') ADVANCE(127);
-      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(17);
       if (lookahead == '~') ADVANCE(132);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(6)
@@ -442,24 +426,24 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\n') SKIP(8)
       if (lookahead == '*') SKIP(8)
       if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '{') ADVANCE(21);
-      if (lookahead == '}') ADVANCE(26);
+      if (lookahead == '@') ADVANCE(17);
+      if (lookahead == '{') ADVANCE(23);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(8)
       if ((11 <= lookahead && lookahead <= '\r')) SKIP(9)
-      if (lookahead != 0) ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '}') ADVANCE(138);
       END_STATE();
     case 9:
       if (lookahead == '\n') SKIP(8)
       if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '{') ADVANCE(21);
-      if (lookahead == '}') ADVANCE(26);
+      if (lookahead == '@') ADVANCE(17);
+      if (lookahead == '{') ADVANCE(23);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(9)
       if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(138);
+          lookahead != '*' &&
+          lookahead != '}') ADVANCE(138);
       END_STATE();
     case 10:
       if (lookahead == '\n') SKIP(10)
@@ -467,7 +451,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '*') SKIP(10)
       if (lookahead == '.') ADVANCE(130);
       if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(17);
       if (lookahead == '~') ADVANCE(132);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(10)
@@ -481,7 +465,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '#') ADVANCE(131);
       if (lookahead == '.') ADVANCE(130);
       if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(17);
       if (lookahead == '~') ADVANCE(132);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(11)
@@ -493,8 +477,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 12:
       if (lookahead == '\n') SKIP(12)
       if (lookahead == '*') SKIP(12)
-      if (lookahead == '{') ADVANCE(21);
-      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '{') ADVANCE(23);
+      if (lookahead == '}') ADVANCE(24);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(12)
       if ((11 <= lookahead && lookahead <= '\r')) SKIP(13)
@@ -503,8 +487,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 13:
       if (lookahead == '\n') SKIP(12)
-      if (lookahead == '{') ADVANCE(21);
-      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '{') ADVANCE(23);
+      if (lookahead == '}') ADVANCE(24);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(13)
       if (lookahead != 0 &&
@@ -512,21 +496,36 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '@') ADVANCE(138);
       END_STATE();
     case 14:
-      if (lookahead == '\n') ADVANCE(23);
+      if (lookahead == '\n') SKIP(14)
+      if (lookahead == '*') SKIP(14)
+      if (lookahead == '/') ADVANCE(140);
       if (lookahead == '@') ADVANCE(17);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(24);
+      if (lookahead == '{') ADVANCE(22);
+      if (lookahead == '\t' ||
+          lookahead == ' ') SKIP(14)
+      if ((11 <= lookahead && lookahead <= '\r')) SKIP(15)
       if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(25);
+          lookahead != '}') ADVANCE(138);
       END_STATE();
     case 15:
+      if (lookahead == '\n') SKIP(14)
+      if (lookahead == '/') ADVANCE(140);
+      if (lookahead == '@') ADVANCE(17);
+      if (lookahead == '{') ADVANCE(22);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(15)
+      if (lookahead != 0 &&
+          lookahead != '*' &&
+          lookahead != '}') ADVANCE(138);
+      END_STATE();
+    case 16:
       if (lookahead == '*') ADVANCE(137);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(15);
+          lookahead != '}') ADVANCE(16);
       END_STATE();
-    case 16:
+    case 17:
       if (lookahead == 'a') ADVANCE(43);
       if (lookahead == 'b') ADVANCE(86);
       if (lookahead == 'c') ADVANCE(33);
@@ -542,49 +541,49 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '_' ||
           ('d' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
-    case 17:
+    case 18:
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(126);
       END_STATE();
-    case 18:
-      if (eof) ADVANCE(20);
-      if (lookahead == '\n') SKIP(18)
+    case 19:
+      if (eof) ADVANCE(21);
+      if (lookahead == '\n') SKIP(19)
       if (lookahead == '#') ADVANCE(131);
-      if (lookahead == '*') SKIP(18)
+      if (lookahead == '*') SKIP(19)
       if (lookahead == '.') ADVANCE(130);
       if (lookahead == '/') ADVANCE(141);
       if (lookahead == ':') ADVANCE(127);
-      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(17);
       if (lookahead == '[') ADVANCE(133);
       if (lookahead == ']') ADVANCE(134);
-      if (lookahead == '{') ADVANCE(21);
-      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '{') ADVANCE(23);
+      if (lookahead == '}') ADVANCE(24);
       if (lookahead == '~') ADVANCE(132);
       if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(18)
-      if ((11 <= lookahead && lookahead <= '\r')) SKIP(19)
+          lookahead == ' ') SKIP(19)
+      if ((11 <= lookahead && lookahead <= '\r')) SKIP(20)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(135);
       if (lookahead != 0) ADVANCE(138);
       END_STATE();
-    case 19:
-      if (eof) ADVANCE(20);
-      if (lookahead == '\n') SKIP(18)
+    case 20:
+      if (eof) ADVANCE(21);
+      if (lookahead == '\n') SKIP(19)
       if (lookahead == '#') ADVANCE(131);
       if (lookahead == '.') ADVANCE(130);
       if (lookahead == '/') ADVANCE(141);
       if (lookahead == ':') ADVANCE(127);
-      if (lookahead == '@') ADVANCE(16);
+      if (lookahead == '@') ADVANCE(17);
       if (lookahead == '[') ADVANCE(133);
       if (lookahead == ']') ADVANCE(134);
-      if (lookahead == '{') ADVANCE(21);
-      if (lookahead == '}') ADVANCE(22);
+      if (lookahead == '{') ADVANCE(23);
+      if (lookahead == '}') ADVANCE(24);
       if (lookahead == '~') ADVANCE(132);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(19)
+          lookahead == ' ') SKIP(20)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
@@ -592,43 +591,29 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '*') ADVANCE(138);
       END_STATE();
-    case 20:
+    case 21:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 21:
+    case 22:
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
-    case 22:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
-      END_STATE();
     case 23:
-      ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token1);
-      if (lookahead == '\n') ADVANCE(23);
-      if (lookahead == '*') ADVANCE(23);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(23);
-      if ((11 <= lookahead && lookahead <= '\r')) ADVANCE(24);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       if (lookahead != 0 &&
           lookahead != '@' &&
-          lookahead != '}') ADVANCE(25);
+          lookahead != '}') ADVANCE(26);
       END_STATE();
     case 24:
-      ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token1);
-      if (lookahead == '\n') ADVANCE(23);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(24);
-      if (lookahead != 0 &&
-          lookahead != '@' &&
-          lookahead != '}') ADVANCE(25);
+      ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
     case 25:
-      ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token1);
-      if (lookahead != 0 &&
-          lookahead != '@' &&
-          lookahead != '}') ADVANCE(25);
+      ACCEPT_TOKEN(sym__inline_tag_false_positive);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token2);
+      ACCEPT_TOKEN(sym__inline_tag_false_positive);
+      if (lookahead == '}') ADVANCE(25);
+      if (lookahead != 0 &&
+          lookahead != '@') ADVANCE(26);
       END_STATE();
     case 27:
       ACCEPT_TOKEN(sym_tag_name_with_argument);
@@ -1386,7 +1371,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\n' &&
           lookahead != '/' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(15);
+          lookahead != '}') ADVANCE(16);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(sym__text);
@@ -1419,56 +1404,52 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [2] = {.lex_state = 4},
   [3] = {.lex_state = 4},
   [4] = {.lex_state = 7},
-  [5] = {.lex_state = 9},
-  [6] = {.lex_state = 11},
+  [5] = {.lex_state = 6},
+  [6] = {.lex_state = 9},
   [7] = {.lex_state = 9},
-  [8] = {.lex_state = 6},
-  [9] = {.lex_state = 9},
-  [10] = {.lex_state = 11},
-  [11] = {.lex_state = 11},
-  [12] = {.lex_state = 9},
+  [8] = {.lex_state = 11},
+  [9] = {.lex_state = 11},
+  [10] = {.lex_state = 9},
+  [11] = {.lex_state = 9},
+  [12] = {.lex_state = 11},
   [13] = {.lex_state = 11},
   [14] = {.lex_state = 11},
   [15] = {.lex_state = 11},
-  [16] = {.lex_state = 0},
-  [17] = {.lex_state = 9},
-  [18] = {.lex_state = 9},
-  [19] = {.lex_state = 9},
-  [20] = {.lex_state = 9},
+  [16] = {.lex_state = 9},
+  [17] = {.lex_state = 15},
+  [18] = {.lex_state = 0},
+  [19] = {.lex_state = 4},
+  [20] = {.lex_state = 4},
   [21] = {.lex_state = 4},
-  [22] = {.lex_state = 4},
-  [23] = {.lex_state = 9},
+  [22] = {.lex_state = 13},
+  [23] = {.lex_state = 13},
   [24] = {.lex_state = 13},
-  [25] = {.lex_state = 13},
-  [26] = {.lex_state = 4},
-  [27] = {.lex_state = 4},
-  [28] = {.lex_state = 13},
-  [29] = {.lex_state = 9},
+  [25] = {.lex_state = 4},
+  [26] = {.lex_state = 9},
+  [27] = {.lex_state = 9},
+  [28] = {.lex_state = 4},
+  [29] = {.lex_state = 4},
   [30] = {.lex_state = 4},
   [31] = {.lex_state = 4},
-  [32] = {.lex_state = 4},
+  [32] = {.lex_state = 13},
   [33] = {.lex_state = 13},
-  [34] = {.lex_state = 4},
+  [34] = {.lex_state = 0},
   [35] = {.lex_state = 13},
-  [36] = {.lex_state = 13},
-  [37] = {.lex_state = 13},
-  [38] = {.lex_state = 14},
+  [36] = {.lex_state = 0, .external_lex_state = 1},
+  [37] = {.lex_state = 0},
+  [38] = {.lex_state = 0},
   [39] = {.lex_state = 0},
-  [40] = {.lex_state = 13},
-  [41] = {.lex_state = 14},
-  [42] = {.lex_state = 0},
+  [40] = {.lex_state = 0},
+  [41] = {.lex_state = 0},
+  [42] = {.lex_state = 2},
   [43] = {.lex_state = 0},
-  [44] = {.lex_state = 0, .external_lex_state = 1},
-  [45] = {.lex_state = 0},
-  [46] = {.lex_state = 0},
-  [47] = {.lex_state = 0, .external_lex_state = 1},
+  [44] = {.lex_state = 0},
+  [45] = {.lex_state = 2},
+  [46] = {.lex_state = 0, .external_lex_state = 1},
+  [47] = {.lex_state = 0},
   [48] = {.lex_state = 0},
   [49] = {.lex_state = 0},
-  [50] = {.lex_state = 0},
-  [51] = {.lex_state = 2},
-  [52] = {.lex_state = 0},
-  [53] = {.lex_state = 0},
-  [54] = {.lex_state = 0},
+  [50] = {.lex_state = 2},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -1476,7 +1457,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [ts_builtin_sym_end] = ACTIONS(1),
     [anon_sym_LBRACE] = ACTIONS(1),
     [anon_sym_RBRACE] = ACTIONS(1),
-    [aux_sym__inline_tag_false_positive_token2] = ACTIONS(1),
+    [sym__inline_tag_false_positive] = ACTIONS(1),
     [sym_tag_name_with_argument] = ACTIONS(1),
     [sym_tag_name_with_type] = ACTIONS(1),
     [sym_tag_name] = ACTIONS(1),
@@ -1494,7 +1475,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_type] = ACTIONS(1),
   },
   [1] = {
-    [sym_document] = STATE(52),
+    [sym_document] = STATE(40),
     [sym__begin] = ACTIONS(3),
   },
 };
@@ -1511,13 +1492,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text,
     ACTIONS(15), 1,
       sym__end,
-    STATE(30), 1,
+    STATE(31), 1,
       sym_description,
     ACTIONS(7), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-    STATE(10), 5,
+    STATE(8), 5,
       sym__expression,
       sym_qualified_expression,
       sym_path_expression,
@@ -1532,13 +1513,13 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text,
     ACTIONS(19), 1,
       sym__end,
-    STATE(31), 1,
+    STATE(29), 1,
       sym_description,
     ACTIONS(17), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-    STATE(6), 5,
+    STATE(9), 5,
       sym__expression,
       sym_qualified_expression,
       sym_path_expression,
@@ -1559,419 +1540,389 @@ static const uint16_t ts_small_parse_table[] = {
       sym_tag_name,
       sym__text,
       sym__end,
-  [78] = 5,
-    ACTIONS(29), 1,
-      anon_sym_LBRACE,
-    ACTIONS(33), 1,
-      sym__text,
-    ACTIONS(35), 1,
-      sym__end,
-    ACTIONS(31), 3,
+  [78] = 3,
+    ACTIONS(23), 1,
+      anon_sym_COLON,
+    ACTIONS(29), 4,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-    STATE(9), 3,
-      sym_inline_tag,
+      sym__text,
+    ACTIONS(31), 4,
+      anon_sym_DOT,
+      anon_sym_POUND,
+      anon_sym_TILDE,
+      sym__end,
+  [94] = 6,
+    ACTIONS(33), 1,
+      anon_sym_LBRACE,
+    ACTIONS(35), 1,
       sym__inline_tag_false_positive,
-      aux_sym_description_repeat1,
-  [98] = 5,
-    ACTIONS(13), 1,
+    ACTIONS(39), 1,
       sym__text,
     ACTIONS(41), 1,
       sym__end,
-    STATE(34), 1,
-      sym_description,
+    STATE(10), 2,
+      sym_inline_tag,
+      aux_sym_description_repeat1,
     ACTIONS(37), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-    ACTIONS(39), 3,
-      anon_sym_DOT,
-      anon_sym_POUND,
-      anon_sym_TILDE,
-  [118] = 5,
+  [116] = 6,
     ACTIONS(43), 1,
       anon_sym_LBRACE,
-    ACTIONS(48), 1,
-      sym__text,
+    ACTIONS(46), 1,
+      sym__inline_tag_false_positive,
     ACTIONS(51), 1,
-      sym__end,
-    ACTIONS(46), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-    STATE(7), 3,
-      sym_inline_tag,
-      sym__inline_tag_false_positive,
-      aux_sym_description_repeat1,
-  [138] = 3,
-    ACTIONS(23), 1,
-      anon_sym_COLON,
-    ACTIONS(53), 4,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
       sym__text,
-    ACTIONS(55), 4,
+    ACTIONS(54), 1,
+      sym__end,
+    STATE(7), 2,
+      sym_inline_tag,
+      aux_sym_description_repeat1,
+    ACTIONS(49), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [138] = 5,
+    ACTIONS(13), 1,
+      sym__text,
+    ACTIONS(60), 1,
+      sym__end,
+    STATE(30), 1,
+      sym_description,
+    ACTIONS(56), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+    ACTIONS(58), 3,
       anon_sym_DOT,
       anon_sym_POUND,
       anon_sym_TILDE,
+  [158] = 5,
+    ACTIONS(13), 1,
+      sym__text,
+    ACTIONS(64), 1,
       sym__end,
-  [154] = 5,
-    ACTIONS(29), 1,
+    STATE(28), 1,
+      sym_description,
+    ACTIONS(58), 3,
+      anon_sym_DOT,
+      anon_sym_POUND,
+      anon_sym_TILDE,
+    ACTIONS(62), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [178] = 6,
+    ACTIONS(33), 1,
       anon_sym_LBRACE,
-    ACTIONS(59), 1,
-      sym__text,
-    ACTIONS(61), 1,
-      sym__end,
-    ACTIONS(57), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-    STATE(7), 3,
-      sym_inline_tag,
+    ACTIONS(66), 1,
       sym__inline_tag_false_positive,
+    ACTIONS(70), 1,
+      sym__text,
+    ACTIONS(72), 1,
+      sym__end,
+    STATE(7), 2,
+      sym_inline_tag,
       aux_sym_description_repeat1,
-  [174] = 5,
+    ACTIONS(68), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [200] = 7,
     ACTIONS(13), 1,
       sym__text,
-    ACTIONS(65), 1,
+    ACTIONS(74), 1,
+      sym_tag_name_with_argument,
+    ACTIONS(76), 1,
+      sym_tag_name_with_type,
+    ACTIONS(78), 1,
+      sym_tag_name,
+    ACTIONS(80), 1,
       sym__end,
-    STATE(32), 1,
+    STATE(19), 1,
       sym_description,
-    ACTIONS(39), 3,
-      anon_sym_DOT,
-      anon_sym_POUND,
-      anon_sym_TILDE,
-    ACTIONS(63), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-  [194] = 2,
-    ACTIONS(67), 4,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-      sym__text,
-    ACTIONS(69), 4,
-      anon_sym_DOT,
-      anon_sym_POUND,
-      anon_sym_TILDE,
-      sym__end,
-  [207] = 7,
-    ACTIONS(13), 1,
-      sym__text,
-    ACTIONS(71), 1,
-      sym_tag_name_with_argument,
-    ACTIONS(73), 1,
-      sym_tag_name_with_type,
-    ACTIONS(75), 1,
-      sym_tag_name,
-    ACTIONS(77), 1,
-      sym__end,
-    STATE(27), 1,
-      sym_description,
-    STATE(26), 2,
+    STATE(25), 2,
       sym_tag,
       aux_sym_document_repeat1,
-  [230] = 2,
-    ACTIONS(79), 4,
+  [223] = 2,
+    ACTIONS(29), 4,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
       sym__text,
-    ACTIONS(81), 4,
+    ACTIONS(31), 4,
       anon_sym_DOT,
       anon_sym_POUND,
       anon_sym_TILDE,
       sym__end,
-  [243] = 2,
-    ACTIONS(83), 4,
+  [236] = 2,
+    ACTIONS(82), 4,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
       sym__text,
-    ACTIONS(85), 4,
+    ACTIONS(84), 4,
       anon_sym_DOT,
       anon_sym_POUND,
       anon_sym_TILDE,
       sym__end,
-  [256] = 2,
-    ACTIONS(53), 4,
+  [249] = 2,
+    ACTIONS(86), 4,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
       sym__text,
-    ACTIONS(55), 4,
+    ACTIONS(88), 4,
       anon_sym_DOT,
       anon_sym_POUND,
       anon_sym_TILDE,
       sym__end,
-  [269] = 3,
+  [262] = 2,
+    ACTIONS(90), 4,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+      sym__text,
+    ACTIONS(92), 4,
+      anon_sym_DOT,
+      anon_sym_POUND,
+      anon_sym_TILDE,
+      sym__end,
+  [275] = 2,
+    ACTIONS(96), 2,
+      sym__inline_tag_false_positive,
+      sym__end,
+    ACTIONS(94), 5,
+      anon_sym_LBRACE,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+      sym__text,
+  [287] = 5,
+    ACTIONS(13), 1,
+      sym__text,
+    ACTIONS(15), 1,
+      sym__end,
+    ACTIONS(98), 1,
+      anon_sym_LBRACE,
+    STATE(31), 1,
+      sym_description,
+    ACTIONS(7), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [305] = 3,
     ACTIONS(9), 1,
       anon_sym_LBRACK,
     ACTIONS(11), 1,
       sym_identifier,
-    STATE(13), 5,
+    STATE(14), 5,
       sym__expression,
       sym_qualified_expression,
       sym_path_expression,
       sym_member_expression,
       sym_optional_identifier,
-  [283] = 5,
-    ACTIONS(13), 1,
-      sym__text,
-    ACTIONS(15), 1,
-      sym__end,
-    ACTIONS(87), 1,
-      anon_sym_LBRACE,
-    STATE(30), 1,
-      sym_description,
-    ACTIONS(7), 3,
+  [319] = 5,
+    ACTIONS(74), 1,
       sym_tag_name_with_argument,
+    ACTIONS(76), 1,
       sym_tag_name_with_type,
+    ACTIONS(78), 1,
       sym_tag_name,
-  [301] = 3,
-    ACTIONS(91), 1,
-      aux_sym__inline_tag_false_positive_token2,
-    ACTIONS(89), 2,
-      anon_sym_LBRACE,
+    ACTIONS(100), 1,
       sym__end,
-    ACTIONS(93), 4,
+    STATE(20), 2,
+      sym_tag,
+      aux_sym_document_repeat1,
+  [336] = 5,
+    ACTIONS(74), 1,
       sym_tag_name_with_argument,
+    ACTIONS(76), 1,
       sym_tag_name_with_type,
+    ACTIONS(78), 1,
       sym_tag_name,
-      sym__text,
-  [315] = 2,
-    ACTIONS(95), 2,
-      anon_sym_LBRACE,
+    ACTIONS(102), 1,
       sym__end,
-    ACTIONS(97), 4,
+    STATE(21), 2,
+      sym_tag,
+      aux_sym_document_repeat1,
+  [353] = 5,
+    ACTIONS(104), 1,
       sym_tag_name_with_argument,
+    ACTIONS(107), 1,
       sym_tag_name_with_type,
+    ACTIONS(110), 1,
       sym_tag_name,
+    ACTIONS(113), 1,
+      sym__end,
+    STATE(21), 2,
+      sym_tag,
+      aux_sym_document_repeat1,
+  [370] = 4,
+    ACTIONS(41), 1,
+      anon_sym_RBRACE,
+    ACTIONS(115), 1,
+      anon_sym_LBRACE,
+    ACTIONS(117), 2,
+      sym__inline_tag_false_positive,
       sym__text,
-  [326] = 4,
+    STATE(23), 2,
+      sym_inline_tag,
+      aux_sym_description_repeat1,
+  [385] = 4,
+    ACTIONS(72), 1,
+      anon_sym_RBRACE,
+    ACTIONS(115), 1,
+      anon_sym_LBRACE,
+    ACTIONS(119), 2,
+      sym__inline_tag_false_positive,
+      sym__text,
+    STATE(24), 2,
+      sym_inline_tag,
+      aux_sym_description_repeat1,
+  [400] = 4,
+    ACTIONS(54), 1,
+      anon_sym_RBRACE,
+    ACTIONS(121), 1,
+      anon_sym_LBRACE,
+    ACTIONS(124), 2,
+      sym__inline_tag_false_positive,
+      sym__text,
+    STATE(24), 2,
+      sym_inline_tag,
+      aux_sym_description_repeat1,
+  [415] = 5,
+    ACTIONS(74), 1,
+      sym_tag_name_with_argument,
+    ACTIONS(76), 1,
+      sym_tag_name_with_type,
+    ACTIONS(78), 1,
+      sym_tag_name,
+    ACTIONS(100), 1,
+      sym__end,
+    STATE(21), 2,
+      sym_tag,
+      aux_sym_document_repeat1,
+  [432] = 4,
     ACTIONS(13), 1,
       sym__text,
     ACTIONS(19), 1,
       sym__end,
-    STATE(31), 1,
+    STATE(29), 1,
       sym_description,
     ACTIONS(17), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-  [341] = 5,
-    ACTIONS(71), 1,
-      sym_tag_name_with_argument,
-    ACTIONS(73), 1,
-      sym_tag_name_with_type,
-    ACTIONS(75), 1,
-      sym_tag_name,
-    ACTIONS(99), 1,
-      sym__end,
-    STATE(22), 2,
-      sym_tag,
-      aux_sym_document_repeat1,
-  [358] = 5,
-    ACTIONS(101), 1,
-      sym_tag_name_with_argument,
-    ACTIONS(104), 1,
-      sym_tag_name_with_type,
-    ACTIONS(107), 1,
-      sym_tag_name,
-    ACTIONS(110), 1,
-      sym__end,
-    STATE(22), 2,
-      sym_tag,
-      aux_sym_document_repeat1,
-  [375] = 2,
-    ACTIONS(112), 2,
-      anon_sym_LBRACE,
-      sym__end,
-    ACTIONS(114), 4,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-      sym__text,
-  [386] = 4,
-    ACTIONS(35), 1,
-      anon_sym_RBRACE,
-    ACTIONS(116), 1,
-      anon_sym_LBRACE,
-    ACTIONS(118), 1,
-      sym__text,
-    STATE(28), 3,
-      sym_inline_tag,
-      sym__inline_tag_false_positive,
-      aux_sym_description_repeat1,
-  [401] = 4,
-    ACTIONS(51), 1,
-      anon_sym_RBRACE,
-    ACTIONS(120), 1,
-      anon_sym_LBRACE,
-    ACTIONS(123), 1,
-      sym__text,
-    STATE(25), 3,
-      sym_inline_tag,
-      sym__inline_tag_false_positive,
-      aux_sym_description_repeat1,
-  [416] = 5,
-    ACTIONS(71), 1,
-      sym_tag_name_with_argument,
-    ACTIONS(73), 1,
-      sym_tag_name_with_type,
-    ACTIONS(75), 1,
-      sym_tag_name,
-    ACTIONS(126), 1,
-      sym__end,
-    STATE(22), 2,
-      sym_tag,
-      aux_sym_document_repeat1,
-  [433] = 5,
-    ACTIONS(71), 1,
-      sym_tag_name_with_argument,
-    ACTIONS(73), 1,
-      sym_tag_name_with_type,
-    ACTIONS(75), 1,
-      sym_tag_name,
-    ACTIONS(126), 1,
-      sym__end,
-    STATE(21), 2,
-      sym_tag,
-      aux_sym_document_repeat1,
-  [450] = 4,
-    ACTIONS(61), 1,
-      anon_sym_RBRACE,
-    ACTIONS(116), 1,
-      anon_sym_LBRACE,
-    ACTIONS(128), 1,
-      sym__text,
-    STATE(25), 3,
-      sym_inline_tag,
-      sym__inline_tag_false_positive,
-      aux_sym_description_repeat1,
-  [465] = 4,
+  [447] = 4,
     ACTIONS(13), 1,
       sym__text,
     ACTIONS(15), 1,
       sym__end,
-    STATE(30), 1,
+    STATE(31), 1,
       sym_description,
     ACTIONS(7), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
-  [480] = 2,
-    ACTIONS(65), 1,
+  [462] = 2,
+    ACTIONS(129), 1,
       sym__end,
-    ACTIONS(63), 3,
+    ACTIONS(127), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [471] = 2,
+    ACTIONS(64), 1,
+      sym__end,
+    ACTIONS(62), 3,
+      sym_tag_name_with_argument,
+      sym_tag_name_with_type,
+      sym_tag_name,
+  [480] = 2,
+    ACTIONS(133), 1,
+      sym__end,
+    ACTIONS(131), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
   [489] = 2,
-    ACTIONS(41), 1,
+    ACTIONS(60), 1,
       sym__end,
-    ACTIONS(37), 3,
+    ACTIONS(56), 3,
       sym_tag_name_with_argument,
       sym_tag_name_with_type,
       sym_tag_name,
   [498] = 2,
-    ACTIONS(132), 1,
-      sym__end,
-    ACTIONS(130), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
+    ACTIONS(94), 1,
+      anon_sym_LBRACE,
+    ACTIONS(96), 3,
+      anon_sym_RBRACE,
+      sym__inline_tag_false_positive,
+      sym__text,
   [507] = 2,
-    ACTIONS(134), 1,
-      aux_sym__inline_tag_false_positive_token2,
-    ACTIONS(89), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
+    ACTIONS(135), 1,
       sym__text,
-  [516] = 2,
-    ACTIONS(138), 1,
-      sym__end,
-    ACTIONS(136), 3,
-      sym_tag_name_with_argument,
-      sym_tag_name_with_type,
-      sym_tag_name,
-  [525] = 1,
-    ACTIONS(112), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      sym__text,
-  [531] = 1,
-    ACTIONS(95), 3,
-      anon_sym_LBRACE,
-      anon_sym_RBRACE,
-      sym__text,
-  [537] = 2,
-    ACTIONS(140), 1,
-      sym__text,
-    STATE(53), 1,
+    STATE(48), 1,
       sym_description,
-  [544] = 2,
-    ACTIONS(142), 1,
-      aux_sym__inline_tag_false_positive_token1,
-    ACTIONS(144), 1,
-      sym_tag_name,
-  [551] = 2,
-    ACTIONS(146), 1,
+  [514] = 2,
+    ACTIONS(137), 1,
       sym_identifier,
-    STATE(15), 1,
+    STATE(12), 1,
       sym_qualified_expression,
-  [558] = 2,
-    ACTIONS(140), 1,
+  [521] = 2,
+    ACTIONS(135), 1,
       sym__text,
-    STATE(45), 1,
+    STATE(39), 1,
       sym_description,
-  [565] = 2,
-    ACTIONS(148), 1,
-      aux_sym__inline_tag_false_positive_token1,
-    ACTIONS(150), 1,
+  [528] = 1,
+    ACTIONS(139), 1,
+      sym_type,
+  [532] = 1,
+    ACTIONS(141), 1,
+      ts_builtin_sym_end,
+  [536] = 1,
+    ACTIONS(143), 1,
+      anon_sym_RBRACE,
+  [540] = 1,
+    ACTIONS(145), 1,
+      anon_sym_RBRACE,
+  [544] = 1,
+    ACTIONS(147), 1,
+      ts_builtin_sym_end,
+  [548] = 1,
+    ACTIONS(149), 1,
+      sym_identifier,
+  [552] = 1,
+    ACTIONS(151), 1,
+      anon_sym_RBRACK,
+  [556] = 1,
+    ACTIONS(153), 1,
+      anon_sym_RBRACE,
+  [560] = 1,
+    ACTIONS(155), 1,
+      ts_builtin_sym_end,
+  [564] = 1,
+    ACTIONS(157), 1,
       sym_tag_name,
+  [568] = 1,
+    ACTIONS(159), 1,
+      sym_type,
   [572] = 1,
-    ACTIONS(152), 1,
+    ACTIONS(161), 1,
       sym_identifier,
   [576] = 1,
-    ACTIONS(154), 1,
-      ts_builtin_sym_end,
+    ACTIONS(163), 1,
+      anon_sym_RBRACE,
   [580] = 1,
-    ACTIONS(156), 1,
-      sym_type,
+    ACTIONS(165), 1,
+      ts_builtin_sym_end,
   [584] = 1,
-    ACTIONS(158), 1,
-      anon_sym_RBRACE,
-  [588] = 1,
-    ACTIONS(160), 1,
-      sym_identifier,
-  [592] = 1,
-    ACTIONS(162), 1,
-      sym_type,
-  [596] = 1,
-    ACTIONS(164), 1,
-      ts_builtin_sym_end,
-  [600] = 1,
-    ACTIONS(166), 1,
-      ts_builtin_sym_end,
-  [604] = 1,
-    ACTIONS(168), 1,
-      anon_sym_RBRACE,
-  [608] = 1,
-    ACTIONS(170), 1,
-      anon_sym_RBRACK,
-  [612] = 1,
-    ACTIONS(172), 1,
-      ts_builtin_sym_end,
-  [616] = 1,
-    ACTIONS(174), 1,
-      anon_sym_RBRACE,
-  [620] = 1,
-    ACTIONS(176), 1,
-      anon_sym_RBRACE,
+    ACTIONS(167), 1,
+      sym_tag_name,
 };
 
 static const uint32_t ts_small_parse_table_map[] = {
@@ -1979,144 +1930,135 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(3)] = 31,
   [SMALL_STATE(4)] = 59,
   [SMALL_STATE(5)] = 78,
-  [SMALL_STATE(6)] = 98,
-  [SMALL_STATE(7)] = 118,
+  [SMALL_STATE(6)] = 94,
+  [SMALL_STATE(7)] = 116,
   [SMALL_STATE(8)] = 138,
-  [SMALL_STATE(9)] = 154,
-  [SMALL_STATE(10)] = 174,
-  [SMALL_STATE(11)] = 194,
-  [SMALL_STATE(12)] = 207,
-  [SMALL_STATE(13)] = 230,
-  [SMALL_STATE(14)] = 243,
-  [SMALL_STATE(15)] = 256,
-  [SMALL_STATE(16)] = 269,
-  [SMALL_STATE(17)] = 283,
-  [SMALL_STATE(18)] = 301,
-  [SMALL_STATE(19)] = 315,
-  [SMALL_STATE(20)] = 326,
-  [SMALL_STATE(21)] = 341,
-  [SMALL_STATE(22)] = 358,
-  [SMALL_STATE(23)] = 375,
-  [SMALL_STATE(24)] = 386,
-  [SMALL_STATE(25)] = 401,
-  [SMALL_STATE(26)] = 416,
-  [SMALL_STATE(27)] = 433,
-  [SMALL_STATE(28)] = 450,
-  [SMALL_STATE(29)] = 465,
+  [SMALL_STATE(9)] = 158,
+  [SMALL_STATE(10)] = 178,
+  [SMALL_STATE(11)] = 200,
+  [SMALL_STATE(12)] = 223,
+  [SMALL_STATE(13)] = 236,
+  [SMALL_STATE(14)] = 249,
+  [SMALL_STATE(15)] = 262,
+  [SMALL_STATE(16)] = 275,
+  [SMALL_STATE(17)] = 287,
+  [SMALL_STATE(18)] = 305,
+  [SMALL_STATE(19)] = 319,
+  [SMALL_STATE(20)] = 336,
+  [SMALL_STATE(21)] = 353,
+  [SMALL_STATE(22)] = 370,
+  [SMALL_STATE(23)] = 385,
+  [SMALL_STATE(24)] = 400,
+  [SMALL_STATE(25)] = 415,
+  [SMALL_STATE(26)] = 432,
+  [SMALL_STATE(27)] = 447,
+  [SMALL_STATE(28)] = 462,
+  [SMALL_STATE(29)] = 471,
   [SMALL_STATE(30)] = 480,
   [SMALL_STATE(31)] = 489,
   [SMALL_STATE(32)] = 498,
   [SMALL_STATE(33)] = 507,
-  [SMALL_STATE(34)] = 516,
-  [SMALL_STATE(35)] = 525,
-  [SMALL_STATE(36)] = 531,
-  [SMALL_STATE(37)] = 537,
-  [SMALL_STATE(38)] = 544,
-  [SMALL_STATE(39)] = 551,
-  [SMALL_STATE(40)] = 558,
-  [SMALL_STATE(41)] = 565,
-  [SMALL_STATE(42)] = 572,
-  [SMALL_STATE(43)] = 576,
-  [SMALL_STATE(44)] = 580,
-  [SMALL_STATE(45)] = 584,
-  [SMALL_STATE(46)] = 588,
-  [SMALL_STATE(47)] = 592,
-  [SMALL_STATE(48)] = 596,
-  [SMALL_STATE(49)] = 600,
-  [SMALL_STATE(50)] = 604,
-  [SMALL_STATE(51)] = 608,
-  [SMALL_STATE(52)] = 612,
-  [SMALL_STATE(53)] = 616,
-  [SMALL_STATE(54)] = 620,
+  [SMALL_STATE(34)] = 514,
+  [SMALL_STATE(35)] = 521,
+  [SMALL_STATE(36)] = 528,
+  [SMALL_STATE(37)] = 532,
+  [SMALL_STATE(38)] = 536,
+  [SMALL_STATE(39)] = 540,
+  [SMALL_STATE(40)] = 544,
+  [SMALL_STATE(41)] = 548,
+  [SMALL_STATE(42)] = 552,
+  [SMALL_STATE(43)] = 556,
+  [SMALL_STATE(44)] = 560,
+  [SMALL_STATE(45)] = 564,
+  [SMALL_STATE(46)] = 568,
+  [SMALL_STATE(47)] = 572,
+  [SMALL_STATE(48)] = 576,
+  [SMALL_STATE(49)] = 580,
+  [SMALL_STATE(50)] = 584,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
-  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(12),
-  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [5] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
   [7] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 1),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
   [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(5),
+  [13] = {.entry = {.count = 1, .reusable = false}}, SHIFT(6),
   [15] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 1),
   [17] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 4),
   [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 4),
   [21] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__expression, 1),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
   [27] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__expression, 1),
-  [29] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
-  [31] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_description, 1),
-  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
-  [35] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_description, 1),
-  [37] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 5),
-  [39] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
-  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 5),
-  [43] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(41),
-  [46] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2),
-  [48] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(7),
-  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2),
-  [53] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_member_expression, 3),
-  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_member_expression, 3),
-  [57] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_description, 2),
-  [59] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
-  [61] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_description, 2),
-  [63] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 2),
-  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
-  [67] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optional_identifier, 3),
-  [69] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optional_identifier, 3),
-  [71] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
-  [73] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
-  [75] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [77] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
-  [79] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_qualified_expression, 3),
-  [81] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_qualified_expression, 3),
-  [83] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_path_expression, 3),
-  [85] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path_expression, 3),
-  [87] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
-  [89] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__inline_tag_false_positive, 2),
-  [91] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [93] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__inline_tag_false_positive, 2),
-  [95] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__inline_tag_false_positive, 3),
-  [97] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__inline_tag_false_positive, 3),
-  [99] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
-  [101] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(2),
-  [104] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(17),
-  [107] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(29),
-  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
-  [112] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_tag, 4),
-  [114] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_tag, 4),
-  [116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
-  [118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
-  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(38),
-  [123] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(25),
-  [126] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(25),
-  [130] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
-  [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
-  [134] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
-  [136] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 6),
-  [138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 6),
-  [140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [142] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
-  [144] = {.entry = {.count = 1, .reusable = false}}, SHIFT(37),
-  [146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [150] = {.entry = {.count = 1, .reusable = false}}, SHIFT(40),
-  [152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
-  [154] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 4),
-  [156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [158] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [160] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
-  [162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3),
-  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2),
-  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
-  [172] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
-  [176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [29] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_member_expression, 3),
+  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_member_expression, 3),
+  [33] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(10),
+  [37] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_description, 1),
+  [39] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
+  [41] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_description, 1),
+  [43] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(45),
+  [46] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(7),
+  [49] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2),
+  [51] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(7),
+  [54] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2),
+  [56] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 2),
+  [58] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [60] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 2),
+  [62] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 5),
+  [64] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 5),
+  [66] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [68] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_description, 2),
+  [70] = {.entry = {.count = 1, .reusable = false}}, SHIFT(7),
+  [72] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_description, 2),
+  [74] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2),
+  [76] = {.entry = {.count = 1, .reusable = false}}, SHIFT(17),
+  [78] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
+  [80] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [82] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_path_expression, 3),
+  [84] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_path_expression, 3),
+  [86] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_qualified_expression, 3),
+  [88] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_qualified_expression, 3),
+  [90] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_optional_identifier, 3),
+  [92] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_optional_identifier, 3),
+  [94] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_tag, 4),
+  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_tag, 4),
+  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
+  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [104] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(2),
+  [107] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(17),
+  [110] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_document_repeat1, 2), SHIFT_REPEAT(27),
+  [113] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2),
+  [115] = {.entry = {.count = 1, .reusable = false}}, SHIFT(50),
+  [117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [121] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(50),
+  [124] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_description_repeat1, 2), SHIFT_REPEAT(24),
+  [127] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 6),
+  [129] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 6),
+  [131] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tag, 3),
+  [133] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tag, 3),
+  [135] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [141] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 4),
+  [143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [145] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [147] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [149] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [153] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [155] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 3),
+  [157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 2),
+  [167] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
 };
 
 enum ts_external_scanner_symbol_identifiers {

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,4 +1,4 @@
-#include "tree_sitter/parser.h"
+#include <tree_sitter/parser.h>
 
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -16,7 +16,7 @@
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
 #define PRODUCTION_ID_COUNT 1
 
-enum ts_symbol_identifiers {
+enum {
   anon_sym_LBRACE = 1,
   anon_sym_RBRACE = 2,
   aux_sym__inline_tag_false_positive_token1 = 3,
@@ -314,276 +314,142 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-<<<<<<< HEAD
-      if (eof) ADVANCE(21);
-      if (lookahead == '\n') SKIP(19)
-      if (lookahead == '#') ADVANCE(128);
-      if (lookahead == '.') ADVANCE(127);
-      if (lookahead == '/') ADVANCE(126);
-      if (lookahead == ':') ADVANCE(124);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '[') ADVANCE(130);
-      if (lookahead == ']') ADVANCE(131);
-      if (lookahead == '{') ADVANCE(22);
-      if (lookahead == '}') ADVANCE(23);
-      if (lookahead == '~') ADVANCE(129);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(20)
-      if (lookahead == '$' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
-      if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(138);
-=======
       if (eof) ADVANCE(20);
       if (lookahead == '\n') SKIP(18)
-      if (lookahead == '#') ADVANCE(120);
-      if (lookahead == '.') ADVANCE(119);
-      if (lookahead == '/') ADVANCE(118);
-      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '#') ADVANCE(130);
+      if (lookahead == '.') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(128);
+      if (lookahead == ':') ADVANCE(126);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '[') ADVANCE(122);
-      if (lookahead == ']') ADVANCE(123);
+      if (lookahead == '[') ADVANCE(132);
+      if (lookahead == ']') ADVANCE(133);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
-      if (lookahead == '~') ADVANCE(121);
+      if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(19)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(127);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          lookahead != '*') ADVANCE(137);
       END_STATE();
     case 1:
       if (lookahead == '\n') SKIP(1)
       if (lookahead == '\r') SKIP(2)
       if (lookahead == '*') SKIP(1)
-<<<<<<< HEAD
-      if (lookahead == '/') ADVANCE(139);
-      if (lookahead == '@') ADVANCE(18);
-      if (lookahead == ']') ADVANCE(131);
-=======
-      if (lookahead == '/') ADVANCE(128);
-      if (lookahead == ']') ADVANCE(123);
->>>>>>> 5ee169e (Permit braces in more contexts)
+      if (lookahead == '/') ADVANCE(138);
+      if (lookahead == ']') ADVANCE(133);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(1)
       END_STATE();
     case 2:
       if (lookahead == '\n') SKIP(1)
-<<<<<<< HEAD
-      if (lookahead == '/') ADVANCE(139);
-      if (lookahead == '@') ADVANCE(18);
-      if (lookahead == ']') ADVANCE(131);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-=======
-      if (lookahead == '/') ADVANCE(128);
-      if (lookahead == ']') ADVANCE(123);
+      if (lookahead == '/') ADVANCE(138);
+      if (lookahead == ']') ADVANCE(133);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
->>>>>>> 5ee169e (Permit braces in more contexts)
           lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
       if (lookahead == '\n') SKIP(3)
       if (lookahead == '\r') SKIP(4)
       if (lookahead == '*') SKIP(3)
-<<<<<<< HEAD
-      if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '[') ADVANCE(130);
-      if (lookahead == '{') ADVANCE(22);
-=======
-      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '[') ADVANCE(122);
+      if (lookahead == '[') ADVANCE(132);
       if (lookahead == '{') ADVANCE(21);
->>>>>>> 5ee169e (Permit braces in more contexts)
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(3)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-<<<<<<< HEAD
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(138);
+          lookahead != '}') ADVANCE(137);
       END_STATE();
     case 4:
       if (lookahead == '\n') SKIP(3)
-      if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '[') ADVANCE(130);
-      if (lookahead == '{') ADVANCE(22);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-=======
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
-      if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(127);
-      END_STATE();
-    case 4:
-      if (lookahead == '\n') SKIP(3)
-      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '[') ADVANCE(122);
+      if (lookahead == '[') ADVANCE(132);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
->>>>>>> 5ee169e (Permit braces in more contexts)
           lookahead == ' ') SKIP(4)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-<<<<<<< HEAD
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       if (lookahead != 0 &&
           lookahead != '*' &&
-          lookahead != '}') ADVANCE(138);
-      END_STATE();
-    case 5:
-      if (lookahead == '\n') SKIP(5)
-      if (lookahead == '#') ADVANCE(128);
-      if (lookahead == '*') SKIP(5)
-      if (lookahead == '.') ADVANCE(127);
-      if (lookahead == '/') ADVANCE(140);
-      if (lookahead == ':') ADVANCE(124);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '~') ADVANCE(129);
-=======
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
-      if (lookahead != 0 &&
-          lookahead != '*' &&
-          lookahead != '}') ADVANCE(127);
+          lookahead != '}') ADVANCE(137);
       END_STATE();
     case 5:
       if (lookahead == '\n') SKIP(5)
       if (lookahead == '\r') SKIP(6)
-      if (lookahead == '#') ADVANCE(120);
+      if (lookahead == '#') ADVANCE(130);
       if (lookahead == '*') SKIP(5)
-      if (lookahead == '.') ADVANCE(119);
-      if (lookahead == '/') ADVANCE(129);
-      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '.') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == ':') ADVANCE(126);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '~') ADVANCE(121);
->>>>>>> 5ee169e (Permit braces in more contexts)
+      if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
       if (lookahead != 0 &&
           lookahead != '{' &&
-<<<<<<< HEAD
-          lookahead != '}') ADVANCE(138);
+          lookahead != '}') ADVANCE(137);
       END_STATE();
     case 6:
       if (lookahead == '\n') SKIP(5)
-      if (lookahead == '#') ADVANCE(128);
-      if (lookahead == '.') ADVANCE(127);
-      if (lookahead == '/') ADVANCE(140);
-      if (lookahead == ':') ADVANCE(124);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '~') ADVANCE(129);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-=======
-          lookahead != '}') ADVANCE(127);
-      END_STATE();
-    case 6:
-      if (lookahead == '\n') SKIP(5)
-      if (lookahead == '#') ADVANCE(120);
-      if (lookahead == '.') ADVANCE(119);
-      if (lookahead == '/') ADVANCE(129);
-      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '#') ADVANCE(130);
+      if (lookahead == '.') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == ':') ADVANCE(126);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '~') ADVANCE(121);
+      if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
->>>>>>> 5ee169e (Permit braces in more contexts)
           lookahead == ' ') SKIP(6)
       if (lookahead != 0 &&
           lookahead != '*' &&
           lookahead != '{' &&
-<<<<<<< HEAD
-          lookahead != '}') ADVANCE(138);
+          lookahead != '}') ADVANCE(137);
       END_STATE();
     case 7:
       if (lookahead == '\n') SKIP(5)
-      if (lookahead == '#') ADVANCE(128);
-      if (lookahead == '.') ADVANCE(127);
-      if (lookahead == '/') ADVANCE(125);
-      if (lookahead == ':') ADVANCE(124);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '~') ADVANCE(129);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-=======
-          lookahead != '}') ADVANCE(127);
-      END_STATE();
-    case 7:
-      if (lookahead == '\n') SKIP(5)
-      if (lookahead == '#') ADVANCE(120);
-      if (lookahead == '.') ADVANCE(119);
-      if (lookahead == '/') ADVANCE(117);
-      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '#') ADVANCE(130);
+      if (lookahead == '.') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(127);
+      if (lookahead == ':') ADVANCE(126);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '~') ADVANCE(121);
+      if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
->>>>>>> 5ee169e (Permit braces in more contexts)
           lookahead == ' ') SKIP(6)
       if (lookahead != 0 &&
           lookahead != '*' &&
           lookahead != '{' &&
-<<<<<<< HEAD
-          lookahead != '}') ADVANCE(138);
-      END_STATE();
-    case 8:
-      if (lookahead == '\n') SKIP(8)
-      if (lookahead == '#') ADVANCE(128);
-      if (lookahead == '*') SKIP(8)
-      if (lookahead == '.') ADVANCE(127);
-      if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '~') ADVANCE(129);
-      if (lookahead == '\t' ||
-          lookahead == ' ') SKIP(8)
-      if ((11 <= lookahead && lookahead <= '\r')) SKIP(9)
-      if (lookahead != 0 &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(138);
-      END_STATE();
-    case 9:
-      if (lookahead == '\n') SKIP(8)
-      if (lookahead == '#') ADVANCE(128);
-      if (lookahead == '.') ADVANCE(127);
-      if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '~') ADVANCE(129);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(9)
-      if (lookahead != 0 &&
-          lookahead != '*' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(138);
-=======
-          lookahead != '}') ADVANCE(127);
+          lookahead != '}') ADVANCE(137);
       END_STATE();
     case 8:
       if (lookahead == '\n') SKIP(8)
       if (lookahead == '\r') SKIP(9)
       if (lookahead == '*') SKIP(8)
-      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(16);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(8)
-      if (lookahead != 0) ADVANCE(127);
+      if (lookahead != 0) ADVANCE(137);
       END_STATE();
     case 9:
       if (lookahead == '\n') SKIP(8)
-      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(16);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
@@ -591,59 +457,37 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '\r' ||
           lookahead == ' ') SKIP(9)
       if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(127);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          lookahead != '*') ADVANCE(137);
       END_STATE();
     case 10:
       if (lookahead == '\n') SKIP(10)
       if (lookahead == '\r') SKIP(11)
-      if (lookahead == '#') ADVANCE(120);
+      if (lookahead == '#') ADVANCE(130);
       if (lookahead == '*') SKIP(10)
-<<<<<<< HEAD
-      if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '{') ADVANCE(22);
-=======
-      if (lookahead == '.') ADVANCE(119);
-      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '.') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '~') ADVANCE(121);
->>>>>>> 5ee169e (Permit braces in more contexts)
+      if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(10)
       if (lookahead != 0 &&
-<<<<<<< HEAD
-          lookahead != '}') ADVANCE(138);
-      END_STATE();
-    case 11:
-      if (lookahead == '\n') SKIP(10)
-      if (lookahead == '/') ADVANCE(140);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '{') ADVANCE(22);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(11)
-      if (lookahead != 0 &&
-          lookahead != '*' &&
-          lookahead != '}') ADVANCE(138);
-=======
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(127);
+          lookahead != '}') ADVANCE(137);
       END_STATE();
     case 11:
       if (lookahead == '\n') SKIP(10)
-      if (lookahead == '#') ADVANCE(120);
-      if (lookahead == '.') ADVANCE(119);
-      if (lookahead == '/') ADVANCE(129);
+      if (lookahead == '#') ADVANCE(130);
+      if (lookahead == '.') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '~') ADVANCE(121);
+      if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(11)
       if (lookahead != 0 &&
           lookahead != '*' &&
           lookahead != '{' &&
-          lookahead != '}') ADVANCE(127);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          lookahead != '}') ADVANCE(137);
       END_STATE();
     case 12:
       if (lookahead == '\n') SKIP(12)
@@ -654,11 +498,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(12)
       if (lookahead != 0 &&
-<<<<<<< HEAD
-          lookahead != '@') ADVANCE(138);
-=======
-          lookahead != '@') ADVANCE(127);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          lookahead != '@') ADVANCE(137);
       END_STATE();
     case 13:
       if (lookahead == '\n') SKIP(12)
@@ -669,29 +509,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') SKIP(13)
       if (lookahead != 0 &&
           lookahead != '*' &&
-<<<<<<< HEAD
-          lookahead != '@') ADVANCE(138);
-      END_STATE();
-    case 14:
-      if (lookahead == '\n') SKIP(14)
-      if (lookahead == '*') ADVANCE(133);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(133);
-      if ((11 <= lookahead && lookahead <= '\r')) ADVANCE(134);
-      if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(135);
-      END_STATE();
-    case 15:
-      if (lookahead == '\n') SKIP(14)
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(134);
-      if (lookahead != 0 &&
-          lookahead != '}') ADVANCE(135);
-      END_STATE();
-    case 16:
-      if (lookahead == '*') ADVANCE(137);
-=======
-          lookahead != '@') ADVANCE(127);
+          lookahead != '@') ADVANCE(137);
       END_STATE();
     case 14:
       if (lookahead == '\n') ADVANCE(23);
@@ -703,145 +521,80 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '}') ADVANCE(25);
       END_STATE();
     case 15:
-      if (lookahead == '*') ADVANCE(126);
->>>>>>> 5ee169e (Permit braces in more contexts)
+      if (lookahead == '*') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '{' &&
           lookahead != '}') ADVANCE(15);
       END_STATE();
     case 16:
-      if (lookahead == 'a') ADVANCE(39);
-      if (lookahead == 'b') ADVANCE(76);
-      if (lookahead == 'c') ADVANCE(30);
-      if (lookahead == 'e') ADVANCE(110);
-      if (lookahead == 'f') ADVANCE(60);
-      if (lookahead == 'm') ADVANCE(57);
-      if (lookahead == 'n') ADVANCE(31);
-      if (lookahead == 'p') ADVANCE(34);
-      if (lookahead == 'r') ADVANCE(45);
-      if (lookahead == 't') ADVANCE(56);
+      if (lookahead == 'a') ADVANCE(42);
+      if (lookahead == 'b') ADVANCE(85);
+      if (lookahead == 'c') ADVANCE(32);
+      if (lookahead == 'e') ADVANCE(120);
+      if (lookahead == 'f') ADVANCE(65);
+      if (lookahead == 'm') ADVANCE(63);
+      if (lookahead == 'n') ADVANCE(33);
+      if (lookahead == 'p') ADVANCE(37);
+      if (lookahead == 'r') ADVANCE(49);
+      if (lookahead == 's') ADVANCE(35);
+      if (lookahead == 't') ADVANCE(62);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('d' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('d' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 17:
-<<<<<<< HEAD
-      if (lookahead == 'a') ADVANCE(39);
-      if (lookahead == 'b') ADVANCE(83);
-      if (lookahead == 'c') ADVANCE(29);
-      if (lookahead == 'e') ADVANCE(118);
-      if (lookahead == 'f') ADVANCE(63);
-      if (lookahead == 'm') ADVANCE(61);
-      if (lookahead == 'n') ADVANCE(30);
-      if (lookahead == 'p') ADVANCE(34);
-      if (lookahead == 'r') ADVANCE(47);
-      if (lookahead == 's') ADVANCE(32);
-      if (lookahead == 't') ADVANCE(60);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('d' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 18:
       if (eof) ADVANCE(20);
       if (lookahead == '\n') SKIP(18)
       if (lookahead == '\r') SKIP(19)
-      if (lookahead == '#') ADVANCE(120);
+      if (lookahead == '#') ADVANCE(130);
       if (lookahead == '*') SKIP(18)
-      if (lookahead == '.') ADVANCE(119);
-      if (lookahead == '/') ADVANCE(130);
-      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '.') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(140);
+      if (lookahead == ':') ADVANCE(126);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '[') ADVANCE(122);
-      if (lookahead == ']') ADVANCE(123);
+      if (lookahead == '[') ADVANCE(132);
+      if (lookahead == ']') ADVANCE(133);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
-      if (lookahead == '~') ADVANCE(121);
+      if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(18)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-<<<<<<< HEAD
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 19:
-      if (eof) ADVANCE(21);
-      if (lookahead == '\n') SKIP(19)
-      if (lookahead == '#') ADVANCE(128);
-      if (lookahead == '*') SKIP(19)
-      if (lookahead == '.') ADVANCE(127);
-      if (lookahead == '/') ADVANCE(141);
-      if (lookahead == ':') ADVANCE(124);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '[') ADVANCE(130);
-      if (lookahead == ']') ADVANCE(131);
-      if (lookahead == '{') ADVANCE(22);
-      if (lookahead == '}') ADVANCE(23);
-      if (lookahead == '~') ADVANCE(129);
-=======
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
-      if (lookahead != 0) ADVANCE(127);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      if (lookahead != 0) ADVANCE(137);
       END_STATE();
     case 19:
       if (eof) ADVANCE(20);
       if (lookahead == '\n') SKIP(18)
-      if (lookahead == '#') ADVANCE(120);
-      if (lookahead == '.') ADVANCE(119);
-      if (lookahead == '/') ADVANCE(130);
-      if (lookahead == ':') ADVANCE(116);
+      if (lookahead == '#') ADVANCE(130);
+      if (lookahead == '.') ADVANCE(129);
+      if (lookahead == '/') ADVANCE(140);
+      if (lookahead == ':') ADVANCE(126);
       if (lookahead == '@') ADVANCE(16);
-      if (lookahead == '[') ADVANCE(122);
-      if (lookahead == ']') ADVANCE(123);
+      if (lookahead == '[') ADVANCE(132);
+      if (lookahead == ']') ADVANCE(133);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
-      if (lookahead == '~') ADVANCE(121);
->>>>>>> 5ee169e (Permit braces in more contexts)
+      if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(19)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-<<<<<<< HEAD
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
-      if (lookahead != 0) ADVANCE(138);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
+      if (lookahead != 0 &&
+          lookahead != '*') ADVANCE(137);
       END_STATE();
     case 20:
-      if (eof) ADVANCE(21);
-      if (lookahead == '\n') SKIP(19)
-      if (lookahead == '#') ADVANCE(128);
-      if (lookahead == '.') ADVANCE(127);
-      if (lookahead == '/') ADVANCE(141);
-      if (lookahead == ':') ADVANCE(124);
-      if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '[') ADVANCE(130);
-      if (lookahead == ']') ADVANCE(131);
-      if (lookahead == '{') ADVANCE(22);
-      if (lookahead == '}') ADVANCE(23);
-      if (lookahead == '~') ADVANCE(129);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(20)
-      if (lookahead == '$' ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
-      if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(138);
-      END_STATE();
-    case 21:
-=======
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
-      if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(127);
-      END_STATE();
-    case 20:
->>>>>>> 5ee169e (Permit braces in more contexts)
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 21:
@@ -862,13 +615,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '}') ADVANCE(25);
       END_STATE();
     case 24:
-<<<<<<< HEAD
-      ACCEPT_TOKEN(sym_tag_name_with_argument);
-      if (lookahead == 'e') ADVANCE(102);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
       ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token1);
       if (lookahead == '\n') ADVANCE(23);
       if (lookahead == '\t' ||
@@ -877,7 +623,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '@' &&
           lookahead != '}') ADVANCE(25);
->>>>>>> 5ee169e (Permit braces in more contexts)
       END_STATE();
     case 25:
       ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token1);
@@ -887,1490 +632,781 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 26:
       ACCEPT_TOKEN(sym_tag_name_with_argument);
-      if (lookahead == 's') ADVANCE(83);
+      if (lookahead == 'e') ADVANCE(104);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 27:
       ACCEPT_TOKEN(sym_tag_name_with_argument);
-      if (lookahead == 's') ADVANCE(91);
+      if (lookahead == 's') ADVANCE(93);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-<<<<<<< HEAD
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 26:
-      ACCEPT_TOKEN(sym_tag_name_with_argument);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 27:
-      ACCEPT_TOKEN(sym_tag_name_with_type);
-      if (lookahead == 's') ADVANCE(28);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 28:
+      ACCEPT_TOKEN(sym_tag_name_with_argument);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 29:
+      ACCEPT_TOKEN(sym_tag_name_with_type);
+      if (lookahead == 'd') ADVANCE(55);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 30:
+      ACCEPT_TOKEN(sym_tag_name_with_type);
+      if (lookahead == 's') ADVANCE(31);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 31:
       ACCEPT_TOKEN(sym_tag_name_with_type);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 29:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(71);
-      if (lookahead == 'o') ADVANCE(76);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 30:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(73);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 31:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(72);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 32:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(112);
+      if (lookahead == 'a') ADVANCE(73);
+      if (lookahead == 'o') ADVANCE(78);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 33:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(40);
+      if (lookahead == 'a') ADVANCE(75);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 34:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(103);
-      if (lookahead == 'r') ADVANCE(85);
+      if (lookahead == 'a') ADVANCE(74);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(69);
+      if (lookahead == 'a') ADVANCE(114);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 36:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(104);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 37:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'a') ADVANCE(43);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 28:
-      ACCEPT_TOKEN(sym_tag_name_with_type);
-      if (lookahead == 's') ADVANCE(29);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 29:
-      ACCEPT_TOKEN(sym_tag_name_with_type);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 30:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(65);
-      if (lookahead == 'o') ADVANCE(70);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 31:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(67);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 32:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(66);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 33:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(40);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 34:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(97);
-      if (lookahead == 'r') ADVANCE(82);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 35:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(63);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 36:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(98);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'a') ADVANCE(44);
+      if (lookahead == 'a') ADVANCE(105);
+      if (lookahead == 'r') ADVANCE(87);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'b') ADVANCE(33);
+      if (lookahead == 'a') ADVANCE(71);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-<<<<<<< HEAD
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(41);
-<<<<<<< HEAD
-      if (lookahead == 'l') ADVANCE(64);
-      if (lookahead == 'p') ADVANCE(62);
-      if (lookahead == 'u') ADVANCE(59);
+      if (lookahead == 'a') ADVANCE(106);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-      if (lookahead == 'l') ADVANCE(59);
-      if (lookahead == 'p') ADVANCE(58);
-      if (lookahead == 'u') ADVANCE(55);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(62);
+      if (lookahead == 'a') ADVANCE(46);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(49);
+      if (lookahead == 'b') ADVANCE(36);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(105);
+      if (lookahead == 'c') ADVANCE(44);
+      if (lookahead == 'l') ADVANCE(66);
+      if (lookahead == 'p') ADVANCE(64);
+      if (lookahead == 'u') ADVANCE(61);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(107);
+      if (lookahead == 'c') ADVANCE(70);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(46);
+      if (lookahead == 'c') ADVANCE(54);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(sym_tag_name);
-<<<<<<< HEAD
-      if (lookahead == 'c') ADVANCE(68);
+      if (lookahead == 'c') ADVANCE(117);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-      if (lookahead == 'e') ADVANCE(102);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(sym_tag_name);
-<<<<<<< HEAD
-      if (lookahead == 'c') ADVANCE(52);
+      if (lookahead == 'c') ADVANCE(50);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-      if (lookahead == 'e') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(sym_tag_name);
-<<<<<<< HEAD
       if (lookahead == 'c') ADVANCE(115);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-      if (lookahead == 'e') ADVANCE(26);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(29);
+      if (lookahead == 'd') ADVANCE(106);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(100);
+      if (lookahead == 'e') ADVANCE(111);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(73);
+      if (lookahead == 'e') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 51:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'c') ADVANCE(48);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-<<<<<<< HEAD
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
-      END_STATE();
-    case 52:
-      ACCEPT_TOKEN(sym_tag_name);
-<<<<<<< HEAD
-      if (lookahead == 'c') ADVANCE(113);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 45:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'd') ADVANCE(104);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 46:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'd') ADVANCE(53);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 47:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(109);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 48:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(26);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 49:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'e') ADVANCE(79);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 50:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(25);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 51:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(46);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(107);
+      if (lookahead == 'e') ADVANCE(27);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(57);
+      if (lookahead == 'e') ADVANCE(29);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(80);
+      if (lookahead == 'e') ADVANCE(109);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(104);
+      if (lookahead == 'e') ADVANCE(59);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'e') ADVANCE(82);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'f') ADVANCE(26);
+      if (lookahead == 'e') ADVANCE(106);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'f') ADVANCE(67);
+      if (lookahead == 'e') ADVANCE(84);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'g') ADVANCE(74);
+      if (lookahead == 'f') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'h') ADVANCE(96);
-      if (lookahead == 'y') ADVANCE(92);
+      if (lookahead == 'f') ADVANCE(69);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(121);
+      if (lookahead == 'g') ADVANCE(76);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(26);
+      if (lookahead == 'h') ADVANCE(98);
+      if (lookahead == 'y') ADVANCE(94);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(98);
-      if (lookahead == 'u') ADVANCE(78);
+      if (lookahead == 'i') ADVANCE(123);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(36);
+      if (lookahead == 'i') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(105);
+      if (lookahead == 'i') ADVANCE(100);
+      if (lookahead == 'u') ADVANCE(81);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(88);
+      if (lookahead == 'i') ADVANCE(39);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(55);
+      if (lookahead == 'i') ADVANCE(107);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'k') ADVANCE(26);
+      if (lookahead == 'i') ADVANCE(90);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 69:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(26);
+      if (lookahead == 'i') ADVANCE(57);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 70:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(38);
+      if (lookahead == 'k') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 71:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(70);
+      if (lookahead == 'l') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 72:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(26);
+      if (lookahead == 'l') ADVANCE(41);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 73:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(50);
+      if (lookahead == 'l') ADVANCE(72);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 74:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(56);
+      if (lookahead == 'm') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 75:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(26);
+      if (lookahead == 'm') ADVANCE(52);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 76:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(106);
+      if (lookahead == 'm') ADVANCE(58);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 77:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 78:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(44);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 79:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(45);
-      if (lookahead == 'r') ADVANCE(81);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 80:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(108);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 81:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(35);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 82:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(111);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 83:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(99);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 84:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(119);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 85:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(90);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 86:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(120);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 87:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(101);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 88:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(75);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 89:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(94);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 90:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(24);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 91:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(37);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 92:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(51);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 93:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(87);
-      if (lookahead == 't') ADVANCE(49);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 94:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(26);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 95:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(117);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 96:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(84);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 97:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(86);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 98:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(55);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 99:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(97);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 100:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(77);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 101:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(111);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 102:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(110);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 103:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(31);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 104:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 's') ADVANCE(26);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 105:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 's') ADVANCE(58);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 106:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 's') ADVANCE(114);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 107:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 's') ADVANCE(104);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 108:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(26);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 109:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(116);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 110:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(122);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 111:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(104);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-      if (lookahead == 'e') ADVANCE(91);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 53:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(96);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'e') ADVANCE(75);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 55:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'g') ADVANCE(68);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 56:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'h') ADVANCE(89);
-      if (lookahead == 'y') ADVANCE(84);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 57:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(113);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 58:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 59:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(36);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 60:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(92);
-      if (lookahead == 'u') ADVANCE(72);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 61:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'i') ADVANCE(80);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 62:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'k') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 63:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 64:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(38);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'l') ADVANCE(64);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 67:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(47);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 68:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'm') ADVANCE(54);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 69:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 70:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(99);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 71:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'n') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 72:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(42);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 73:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(101);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 74:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(35);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 75:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'n') ADVANCE(104);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 76:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(93);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 77:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(111);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 78:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(112);
+      if (lookahead == 'n') ADVANCE(108);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 79:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(95);
+      if (lookahead == 'n') ADVANCE(48);
+      if (lookahead == 'r') ADVANCE(83);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 80:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(69);
+      if (lookahead == 'n') ADVANCE(30);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 81:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(87);
+      if (lookahead == 'n') ADVANCE(47);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 82:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'o') ADVANCE(86);
+      if (lookahead == 'n') ADVANCE(110);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 83:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(37);
+      if (lookahead == 'n') ADVANCE(38);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(48);
+      if (lookahead == 'n') ADVANCE(113);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'p') ADVANCE(79);
-      if (lookahead == 't') ADVANCE(52);
+      if (lookahead == 'o') ADVANCE(101);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 86:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(121);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 87:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(92);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 88:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(122);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 89:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(103);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 90:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(77);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 91:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'o') ADVANCE(96);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 92:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'p') ADVANCE(26);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 93:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'p') ADVANCE(40);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 94:
       ACCEPT_TOKEN(sym_tag_name);
       if (lookahead == 'p') ADVANCE(53);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 87:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 88:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(109);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 89:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(77);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 90:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(78);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 91:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(74);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 92:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(51);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 93:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(90);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
-      END_STATE();
-    case 94:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(71);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(104);
+      if (lookahead == 'p') ADVANCE(89);
+      if (lookahead == 't') ADVANCE(51);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 96:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(103);
+      if (lookahead == 'r') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 97:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'r') ADVANCE(32);
+      if (lookahead == 'r') ADVANCE(119);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 98:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 's') ADVANCE(27);
+      if (lookahead == 'r') ADVANCE(86);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
-    case 112:
+    case 99:
       ACCEPT_TOKEN(sym_tag_name);
-<<<<<<< HEAD
-      if (lookahead == 't') ADVANCE(65);
+      if (lookahead == 'r') ADVANCE(88);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-      if (lookahead == 's') ADVANCE(106);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
-    case 113:
+    case 100:
       ACCEPT_TOKEN(sym_tag_name);
-<<<<<<< HEAD
-      if (lookahead == 't') ADVANCE(66);
+      if (lookahead == 'r') ADVANCE(57);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-      if (lookahead == 's') ADVANCE(98);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
-    case 114:
+    case 101:
       ACCEPT_TOKEN(sym_tag_name);
-<<<<<<< HEAD
-      if (lookahead == 't') ADVANCE(95);
+      if (lookahead == 'r') ADVANCE(99);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-      if (lookahead == 't') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
-    case 115:
+    case 102:
       ACCEPT_TOKEN(sym_tag_name);
-<<<<<<< HEAD
-      if (lookahead == 't') ADVANCE(89);
+      if (lookahead == 'r') ADVANCE(80);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-=======
-      if (lookahead == 't') ADVANCE(108);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
->>>>>>> 5ee169e (Permit braces in more contexts)
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
-    case 116:
+    case 103:
       ACCEPT_TOKEN(sym_tag_name);
-<<<<<<< HEAD
-      if (lookahead == 'u') ADVANCE(100);
+      if (lookahead == 'r') ADVANCE(113);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 117:
-=======
-      if (lookahead == 't') ADVANCE(114);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 104:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(98);
+      if (lookahead == 'r') ADVANCE(112);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 105:
->>>>>>> 5ee169e (Permit braces in more contexts)
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(61);
+      if (lookahead == 'r') ADVANCE(34);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-<<<<<<< HEAD
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 118:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'v') ADVANCE(54);
-      if (lookahead == 'x') ADVANCE(93);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 119:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'w') ADVANCE(27);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 120:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'w') ADVANCE(104);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 121:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'x') ADVANCE(55);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 122:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'y') ADVANCE(26);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 123:
-      ACCEPT_TOKEN(sym_tag_name);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(123);
-      END_STATE();
-    case 124:
-      ACCEPT_TOKEN(anon_sym_COLON);
-      END_STATE();
-    case 125:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      END_STATE();
-    case 126:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      if (lookahead == '*') ADVANCE(139);
-      END_STATE();
-    case 127:
-      ACCEPT_TOKEN(anon_sym_DOT);
-      END_STATE();
-    case 128:
-      ACCEPT_TOKEN(anon_sym_POUND);
-      END_STATE();
-    case 129:
-      ACCEPT_TOKEN(anon_sym_TILDE);
-      END_STATE();
-    case 130:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
-      END_STATE();
-    case 131:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
-      END_STATE();
-    case 132:
-=======
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(88);
+      if (lookahead == 's') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 't') ADVANCE(81);
+      if (lookahead == 's') ADVANCE(60);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 108:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'u') ADVANCE(94);
+      if (lookahead == 's') ADVANCE(116);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 109:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'u') ADVANCE(43);
+      if (lookahead == 's') ADVANCE(106);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'v') ADVANCE(50);
-      if (lookahead == 'x') ADVANCE(85);
+      if (lookahead == 't') ADVANCE(28);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'w') ADVANCE(28);
+      if (lookahead == 't') ADVANCE(118);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 112:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'w') ADVANCE(98);
+      if (lookahead == 't') ADVANCE(124);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'x') ADVANCE(51);
+      if (lookahead == 't') ADVANCE(106);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym_tag_name);
-      if (lookahead == 'y') ADVANCE(27);
+      if (lookahead == 't') ADVANCE(67);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 't') ADVANCE(68);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(115);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 116:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 't') ADVANCE(97);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 117:
-      ACCEPT_TOKEN(anon_sym_SLASH);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 't') ADVANCE(91);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 118:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      if (lookahead == '*') ADVANCE(128);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'u') ADVANCE(102);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 119:
-      ACCEPT_TOKEN(anon_sym_DOT);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'u') ADVANCE(45);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 120:
-      ACCEPT_TOKEN(anon_sym_POUND);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'v') ADVANCE(56);
+      if (lookahead == 'x') ADVANCE(95);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 121:
-      ACCEPT_TOKEN(anon_sym_TILDE);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'w') ADVANCE(30);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 122:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'w') ADVANCE(106);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 123:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'x') ADVANCE(57);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
       END_STATE();
     case 124:
->>>>>>> 5ee169e (Permit braces in more contexts)
+      ACCEPT_TOKEN(sym_tag_name);
+      if (lookahead == 'y') ADVANCE(28);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 125:
+      ACCEPT_TOKEN(sym_tag_name);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(125);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      if (lookahead == '*') ADVANCE(138);
+      END_STATE();
+    case 129:
+      ACCEPT_TOKEN(anon_sym_DOT);
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(anon_sym_POUND);
+      END_STATE();
+    case 131:
+      ACCEPT_TOKEN(anon_sym_TILDE);
+      END_STATE();
+    case 132:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      END_STATE();
+    case 134:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == '$' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-<<<<<<< HEAD
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(132);
-      END_STATE();
-    case 133:
-      ACCEPT_TOKEN(sym_type);
-      if (lookahead == '*') ADVANCE(133);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(133);
-      if ((11 <= lookahead && lookahead <= '\r')) ADVANCE(134);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '}') ADVANCE(135);
-      END_STATE();
-    case 134:
-      ACCEPT_TOKEN(sym_type);
-      if (lookahead == '\t' ||
-          (11 <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(134);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '}') ADVANCE(135);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(134);
       END_STATE();
     case 135:
-      ACCEPT_TOKEN(sym_type);
+      ACCEPT_TOKEN(sym__text);
+      if (lookahead == '*') ADVANCE(136);
+      if (lookahead == '/') ADVANCE(135);
       if (lookahead != 0 &&
           lookahead != '\n' &&
+          lookahead != '{' &&
           lookahead != '}') ADVANCE(135);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(sym__text);
-      if (lookahead == '*') ADVANCE(137);
-      if (lookahead == '/') ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(136);
-=======
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(124);
->>>>>>> 5ee169e (Permit braces in more contexts)
-      END_STATE();
-    case 137:
-      ACCEPT_TOKEN(sym__text);
-<<<<<<< HEAD
-      if (lookahead == '*') ADVANCE(137);
-=======
-      if (lookahead == '*') ADVANCE(126);
-      if (lookahead == '/') ADVANCE(125);
-      if (lookahead != 0 &&
-          lookahead != '\n' &&
-          lookahead != '{' &&
-          lookahead != '}') ADVANCE(125);
-      END_STATE();
-    case 126:
-      ACCEPT_TOKEN(sym__text);
-      if (lookahead == '*') ADVANCE(126);
->>>>>>> 5ee169e (Permit braces in more contexts)
+      if (lookahead == '*') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '/' &&
           lookahead != '{' &&
           lookahead != '}') ADVANCE(15);
       END_STATE();
-<<<<<<< HEAD
-    case 138:
+    case 137:
       ACCEPT_TOKEN(sym__text);
-      if (lookahead == '/') ADVANCE(138);
-=======
-    case 127:
-      ACCEPT_TOKEN(sym__text);
-      if (lookahead == '/') ADVANCE(127);
->>>>>>> 5ee169e (Permit braces in more contexts)
+      if (lookahead == '/') ADVANCE(137);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != '*' &&
           lookahead != '{' &&
-<<<<<<< HEAD
-          lookahead != '}') ADVANCE(136);
+          lookahead != '}') ADVANCE(135);
+      END_STATE();
+    case 138:
+      ACCEPT_TOKEN(sym__begin);
+      if (lookahead == '*') ADVANCE(138);
       END_STATE();
     case 139:
-      ACCEPT_TOKEN(sym__begin);
-      if (lookahead == '*') ADVANCE(139);
+      ACCEPT_TOKEN(sym__end);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(sym__end);
-=======
-          lookahead != '}') ADVANCE(125);
-      END_STATE();
-    case 128:
-      ACCEPT_TOKEN(sym__begin);
-      if (lookahead == '*') ADVANCE(128);
->>>>>>> 5ee169e (Permit braces in more contexts)
-      END_STATE();
-    case 141:
-      ACCEPT_TOKEN(sym__end);
-<<<<<<< HEAD
-      if (lookahead == '*') ADVANCE(139);
-=======
-      END_STATE();
-    case 130:
-      ACCEPT_TOKEN(sym__end);
-      if (lookahead == '*') ADVANCE(128);
->>>>>>> 5ee169e (Permit braces in more contexts)
+      if (lookahead == '*') ADVANCE(138);
       END_STATE();
     default:
       return false;

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,4 +1,4 @@
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -16,7 +16,7 @@
 #define MAX_ALIAS_SEQUENCE_LENGTH 6
 #define PRODUCTION_ID_COUNT 1
 
-enum {
+enum ts_symbol_identifiers {
   anon_sym_LBRACE = 1,
   anon_sym_RBRACE = 2,
   aux_sym__inline_tag_false_positive_token1 = 3,
@@ -326,8 +326,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
       if (lookahead == '~') ADVANCE(131);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(19)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
@@ -338,24 +337,22 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 1:
       if (lookahead == '\n') SKIP(1)
-      if (lookahead == '\r') SKIP(2)
       if (lookahead == '*') SKIP(1)
       if (lookahead == '/') ADVANCE(138);
       if (lookahead == ']') ADVANCE(133);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(1)
+      if ((11 <= lookahead && lookahead <= '\r')) SKIP(2)
       END_STATE();
     case 2:
       if (lookahead == '\n') SKIP(1)
       if (lookahead == '/') ADVANCE(138);
       if (lookahead == ']') ADVANCE(133);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(2)
       END_STATE();
     case 3:
       if (lookahead == '\n') SKIP(3)
-      if (lookahead == '\r') SKIP(4)
       if (lookahead == '*') SKIP(3)
       if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(16);
@@ -363,6 +360,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(3)
+      if ((11 <= lookahead && lookahead <= '\r')) SKIP(4)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
@@ -376,8 +374,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '@') ADVANCE(16);
       if (lookahead == '[') ADVANCE(132);
       if (lookahead == '{') ADVANCE(21);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(4)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
@@ -389,7 +386,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 5:
       if (lookahead == '\n') SKIP(5)
-      if (lookahead == '\r') SKIP(6)
       if (lookahead == '#') ADVANCE(130);
       if (lookahead == '*') SKIP(5)
       if (lookahead == '.') ADVANCE(129);
@@ -399,6 +395,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(5)
+      if ((11 <= lookahead && lookahead <= '\r')) SKIP(6)
       if (lookahead != 0 &&
           lookahead != '{' &&
           lookahead != '}') ADVANCE(137);
@@ -411,8 +408,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == ':') ADVANCE(126);
       if (lookahead == '@') ADVANCE(16);
       if (lookahead == '~') ADVANCE(131);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(6)
       if (lookahead != 0 &&
           lookahead != '*' &&
@@ -427,8 +423,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == ':') ADVANCE(126);
       if (lookahead == '@') ADVANCE(16);
       if (lookahead == '~') ADVANCE(131);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(6)
       if (lookahead != 0 &&
           lookahead != '*' &&
@@ -437,7 +432,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 8:
       if (lookahead == '\n') SKIP(8)
-      if (lookahead == '\r') SKIP(9)
       if (lookahead == '*') SKIP(8)
       if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(16);
@@ -445,6 +439,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '}') ADVANCE(22);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(8)
+      if ((11 <= lookahead && lookahead <= '\r')) SKIP(9)
       if (lookahead != 0) ADVANCE(137);
       END_STATE();
     case 9:
@@ -453,15 +448,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '@') ADVANCE(16);
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(9)
       if (lookahead != 0 &&
           lookahead != '*') ADVANCE(137);
       END_STATE();
     case 10:
       if (lookahead == '\n') SKIP(10)
-      if (lookahead == '\r') SKIP(11)
       if (lookahead == '#') ADVANCE(130);
       if (lookahead == '*') SKIP(10)
       if (lookahead == '.') ADVANCE(129);
@@ -470,6 +463,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(10)
+      if ((11 <= lookahead && lookahead <= '\r')) SKIP(11)
       if (lookahead != 0 &&
           lookahead != '{' &&
           lookahead != '}') ADVANCE(137);
@@ -481,8 +475,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '/') ADVANCE(139);
       if (lookahead == '@') ADVANCE(16);
       if (lookahead == '~') ADVANCE(131);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(11)
       if (lookahead != 0 &&
           lookahead != '*' &&
@@ -491,12 +484,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 12:
       if (lookahead == '\n') SKIP(12)
-      if (lookahead == '\r') SKIP(13)
       if (lookahead == '*') SKIP(12)
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(12)
+      if ((11 <= lookahead && lookahead <= '\r')) SKIP(13)
       if (lookahead != 0 &&
           lookahead != '@') ADVANCE(137);
       END_STATE();
@@ -504,8 +497,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\n') SKIP(12)
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(13)
       if (lookahead != 0 &&
           lookahead != '*' &&
@@ -514,8 +506,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 14:
       if (lookahead == '\n') ADVANCE(23);
       if (lookahead == '@') ADVANCE(17);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') ADVANCE(24);
       if (lookahead != 0 &&
           lookahead != '}') ADVANCE(25);
@@ -551,7 +542,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 18:
       if (eof) ADVANCE(20);
       if (lookahead == '\n') SKIP(18)
-      if (lookahead == '\r') SKIP(19)
       if (lookahead == '#') ADVANCE(130);
       if (lookahead == '*') SKIP(18)
       if (lookahead == '.') ADVANCE(129);
@@ -565,6 +555,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '~') ADVANCE(131);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(18)
+      if ((11 <= lookahead && lookahead <= '\r')) SKIP(19)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
@@ -584,8 +575,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '{') ADVANCE(21);
       if (lookahead == '}') ADVANCE(22);
       if (lookahead == '~') ADVANCE(131);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(19)
       if (lookahead == '$' ||
           ('A' <= lookahead && lookahead <= 'Z') ||
@@ -606,10 +596,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 23:
       ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token1);
       if (lookahead == '\n') ADVANCE(23);
-      if (lookahead == '\r') ADVANCE(24);
       if (lookahead == '*') ADVANCE(23);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(23);
+      if ((11 <= lookahead && lookahead <= '\r')) ADVANCE(24);
       if (lookahead != 0 &&
           lookahead != '@' &&
           lookahead != '}') ADVANCE(25);
@@ -617,8 +607,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 24:
       ACCEPT_TOKEN(aux_sym__inline_tag_false_positive_token1);
       if (lookahead == '\n') ADVANCE(23);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
+      if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') ADVANCE(24);
       if (lookahead != 0 &&
           lookahead != '@' &&
@@ -1470,20 +1459,6 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [53] = {.lex_state = 0},
 };
 
-enum {
-  ts_external_token_type = 0,
-};
-
-static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
-  [ts_external_token_type] = sym_type,
-};
-
-static const bool ts_external_scanner_states[2][EXTERNAL_TOKEN_COUNT] = {
-  [1] = {
-    [ts_external_token_type] = true,
-  },
-};
-
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
@@ -2120,6 +2095,20 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [170] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
   [172] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
   [174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+};
+
+enum ts_external_scanner_symbol_identifiers {
+  ts_external_token_type = 0,
+};
+
+static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
+  [ts_external_token_type] = sym_type,
+};
+
+static const bool ts_external_scanner_states[2][EXTERNAL_TOKEN_COUNT] = {
+  [1] = {
+    [ts_external_token_type] = true,
+  },
 };
 
 #ifdef __cplusplus

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -16,6 +16,9 @@ void tree_sitter_jsdoc_external_scanner_deserialize(void *p, const char *b, unsi
 bool scan_for_type(TSLexer *lexer) {
   int stack = 0;
   while (true) {
+    if (lexer->eof(lexer)) {
+      return false;
+    }
     switch (lexer->lookahead) {
       case '{':
         stack++;
@@ -25,6 +28,7 @@ bool scan_for_type(TSLexer *lexer) {
         if (stack == -1) { return true; }
         break;
       case '\n':
+      case '\0': // fallthrough
         // Something's gone wrong.
         return false;
       default:;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,6 +1,4 @@
 #include "tree_sitter/parser.h"
-#include <wctype.h>
-#include <stdio.h>
 
 enum TokenType {
   TYPE_TOKEN

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,4 +1,4 @@
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 #include <wctype.h>
 #include <stdio.h>
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,0 +1,44 @@
+#include <tree_sitter/parser.h>
+#include <wctype.h>
+#include <stdio.h>
+
+enum TokenType {
+  TYPE_TOKEN
+};
+
+void *tree_sitter_jsdoc_external_scanner_create() { return NULL; }
+void tree_sitter_jsdoc_external_scanner_destroy(void *p) {}
+void tree_sitter_jsdoc_external_scanner_reset(void *p) {}
+unsigned tree_sitter_jsdoc_external_scanner_serialize(void *p, char *buffer) { return 0; }
+void tree_sitter_jsdoc_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
+
+// Scan to the next balanced `}` character.
+bool scan_for_type(TSLexer *lexer) {
+  int stack = 0;
+  while (true) {
+    switch (lexer->lookahead) {
+      case '{':
+        stack++;
+        break;
+      case '}':
+        stack--;
+        if (stack == -1) { return true; }
+        break;
+      case '\n':
+        // Something's gone wrong.
+        return false;
+      default:;
+    }
+    lexer->advance(lexer, false);
+  }
+}
+
+bool tree_sitter_jsdoc_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+  if (valid_symbols[TYPE_TOKEN] && scan_for_type(lexer)) {
+    lexer->result_symbol = TYPE_TOKEN;
+    lexer->mark_end(lexer);
+    return true;
+  }
+
+  return false;
+}

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -13,7 +13,7 @@ unsigned tree_sitter_jsdoc_external_scanner_serialize(void *p, char *buffer) { r
 void tree_sitter_jsdoc_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
 
 // Scan to the next balanced `}` character.
-bool scan_for_type(TSLexer *lexer) {
+static bool scan_for_type(TSLexer *lexer) {
   int stack = 0;
   while (true) {
     if (lexer->eof(lexer)) {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,9 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -130,9 +129,16 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -166,7 +172,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
 
 #define STATE(id) id
 
@@ -176,7 +182,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value            \
+      .state = (state_value)          \
     }                                 \
   }}
 
@@ -184,7 +190,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value,           \
+      .state = (state_value),         \
       .repetition = true              \
     }                                 \
   }}

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -130,16 +130,9 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -172,7 +173,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -182,7 +183,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -190,7 +191,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}

--- a/test/corpus/braces.txt
+++ b/test/corpus/braces.txt
@@ -80,6 +80,7 @@ EOF before balanced braces
 ---
 
 (document
+  (description)
   (tag
     (tag_name)
     (ERROR)

--- a/test/corpus/braces.txt
+++ b/test/corpus/braces.txt
@@ -69,3 +69,19 @@ Complex types
     (type)
     (identifier)
     (description)))
+
+=======================================
+EOF before balanced braces
+=======================================
+
+/**
+ * Here we're testing that the scanner doesn't get stuck in an infinite loop.
+ * @type {{a: number, b: string, c}
+---
+
+(document
+  (tag
+    (tag_name)
+    (ERROR)
+    (type))
+  (MISSING _end))

--- a/test/corpus/braces.txt
+++ b/test/corpus/braces.txt
@@ -79,10 +79,6 @@ EOF before balanced braces
  * @type {{a: number, b: string, c}
 ---
 
-(document
+(ERROR
   (description)
-  (tag
-    (tag_name)
-    (ERROR)
-    (type))
-  (MISSING _end))
+  (tag_name))

--- a/test/corpus/braces.txt
+++ b/test/corpus/braces.txt
@@ -1,0 +1,71 @@
+=======================================
+Usages of braces outside of inline tags
+=======================================
+
+/** This is {something} that should not {error}. */
+
+---
+
+(document (description))
+
+=======================================
+Unmarked code example
+=======================================
+
+/**
+ *  @alias Apple.Core
+ *  @event module:foo/bar.event:MyEvent
+ *  @fires Hurl#snowball
+ *  @exports hello/world
+ *  @example apple.core({ foo: 'x', bar: true });
+ */
+
+---
+
+(document
+  (tag
+    (tag_name)
+    (member_expression (identifier) (identifier)))
+  (tag
+    (tag_name)
+    (member_expression
+      (qualified_expression
+        (identifier)
+        (path_expression (identifier) (identifier)))
+      (qualified_expression (identifier) (identifier))))
+  (tag
+    (tag_name)
+    (member_expression (identifier) (identifier)))
+  (tag
+    (tag_name)
+    (path_expression (identifier) (identifier)))
+  (tag
+    (tag_name) (description))
+)
+
+=======================================
+Complex types
+=======================================
+
+/**
+ * @type {{a: number, b: string, c}}
+ * @param {[a: number, b:string]} foo A parameter.
+ * @param {[a: number, { b: string, c: boolean}]} foo A parameter.
+ */
+
+---
+
+(document
+  (tag
+    (tag_name)
+    (type))
+  (tag
+    (tag_name)
+    (type)
+    (identifier)
+    (description))
+  (tag
+    (tag_name)
+    (type)
+    (identifier)
+    (description)))


### PR DESCRIPTION
Fixes #1.

Allows for free use of `{` and `}` in descriptions when they're not part of inline tags. Also allows for braces in type descriptions as long as they're balanced.

In the wild I'm often seeing more liberal usage of JSDoc syntax than what this parser allows. This parser doesn't tolerate curly braces in descriptions except as inline tags, but [here's one example](https://github.com/atom-community/atom-languageclient/blob/master/lib/auto-languageclient.ts#L299-L314) that illustrates two different usages that run afoul of that:

1. Casual usage of type-style syntax in descriptions (e.g., `Returns a two-item {Array}.`). I don't know whether this syntax has meaning for some tool out there, but I see it often enough that I figure it must.
2. Code examples that include curly braces.

Here's how that code example looks in Pulsar (alongside a playground-style view of the tree):

<p><img width="997" alt="illustration of parser failure" src="https://github.com/tree-sitter/tree-sitter-jsdoc/assets/3450/0181e18a-2fee-47dc-af25-bd7884860642"></p>

Neither of these usages seems to be expressly prohibited by the JSDoc spec (such as it is), so this PR aims to tolerate both of these usages without putting errors into the tree and without giving these constructs any special treatment that the spec doesn't recognize.

After I fixed this, I realized that there was one more brace-related failure that is explicitly allowed by the spec. The [type formats allowed in JSDoc](https://jsdoc.app/tags-type) include some with braces — e.g., `{{a: number, b: string, c}}` — so I wanted to make sure the parser tolerated that. I decided to turn `type` into an external, as it was the easiest way I could think of to keep track of when the braces were balanced.

I also added the `@type` tag. There are other tags that could be added, but I can tackle that in a separate PR.